### PR TITLE
main: graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sync"
+	"syscall"
 
 	"github.com/yvasiyarov/gorelic"
 
@@ -28,14 +32,14 @@ func startApi() {
 	s.Start()
 }
 
-func startBlockUnlocker() {
+func startBlockUnlocker(ctx context.Context) {
 	u := payouts.NewBlockUnlocker(&cfg.BlockUnlocker, backend, &cfg.Network)
-	u.Start()
+	u.Start(ctx)
 }
 
-func startPayoutsProcessor() {
+func startPayoutsProcessor(ctx context.Context) {
 	u := payouts.NewPayoutsProcessor(&cfg.Payouts, backend)
-	u.Start()
+	u.Start(ctx)
 }
 
 func startNewrelic() {
@@ -85,6 +89,15 @@ func main() {
 		log.Printf("Backend check reply: %v", pong)
 	}
 
+	// Shut down cleanly on SIGINT/SIGTERM.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// The proxy and API are network servers, torn down when the process exits.
+	// The block unlocker and payouts processor mutate balances, so we wait for
+	// them to finish the current cycle before exiting.
+	var wg sync.WaitGroup
+
 	if cfg.Proxy.Enabled {
 		go startProxy()
 	}
@@ -92,11 +105,23 @@ func main() {
 		go startApi()
 	}
 	if cfg.BlockUnlocker.Enabled {
-		go startBlockUnlocker()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startBlockUnlocker(ctx)
+		}()
 	}
 	if cfg.Payouts.Enabled {
-		go startPayoutsProcessor()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startPayoutsProcessor(ctx)
+		}()
 	}
-	quit := make(chan bool)
-	<-quit
+
+	<-ctx.Done()
+	stop() // a second signal terminates immediately
+	log.Println("Shutting down; waiting for unlocker/payouts to finish the current cycle...")
+	wg.Wait()
+	log.Println("Shutdown complete")
 }

--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -1,6 +1,7 @@
 package payouts
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/big"
@@ -56,7 +57,7 @@ func NewPayoutsProcessor(cfg *PayoutsConfig, backend *storage.RedisClient) *Payo
 	return u
 }
 
-func (u *PayoutsProcessor) Start() {
+func (u *PayoutsProcessor) Start(ctx context.Context) {
 	log.Println("Starting payouts")
 
 	if u.mustResolvePayout() {
@@ -91,15 +92,17 @@ func (u *PayoutsProcessor) Start() {
 	u.process()
 	timer.Reset(intv)
 
-	go func() {
-		for {
-			select {
-			case <-timer.C:
-				u.process()
-				timer.Reset(intv)
-			}
+	for {
+		select {
+		case <-timer.C:
+			u.process()
+			timer.Reset(intv)
+		case <-ctx.Done():
+			log.Println("Stopping payouts")
+			timer.Stop()
+			return
 		}
-	}()
+	}
 }
 
 func (u *PayoutsProcessor) process() {

--- a/payouts/shutdown_test.go
+++ b/payouts/shutdown_test.go
@@ -1,0 +1,58 @@
+package payouts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+// Graceful shutdown: the block unlocker and payouts processor must return from
+// Start when their context is cancelled, instead of looping forever. The daemon
+// is pointed at an unreachable address so the initial cycle fails fast (its
+// errors are handled) and we reach the select loop, where the cancelled context
+// must make Start return promptly.
+
+func assertStartReturns(t *testing.T, name string, start func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		start()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("%s.Start did not return after its context was cancelled", name)
+	}
+}
+
+func TestBlockUnlockerStopsOnContextCancel(t *testing.T) {
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, "test-graceful-unlocker")
+	network := "classic"
+	u := NewBlockUnlocker(&UnlockerConfig{
+		Interval:      "1h",
+		Depth:         120,
+		ImmatureDepth: 20,
+		Daemon:        "http://127.0.0.1:1",
+		Timeout:       "1s",
+	}, backend, &network)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assertStartReturns(t, "BlockUnlocker", func() { u.Start(ctx) })
+}
+
+func TestPayoutsProcessorStopsOnContextCancel(t *testing.T) {
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, "test-graceful-payer")
+	u := NewPayoutsProcessor(&PayoutsConfig{
+		Interval: "1h",
+		Daemon:   "http://127.0.0.1:1",
+		Timeout:  "1s",
+	}, backend)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assertStartReturns(t, "PayoutsProcessor", func() { u.Start(ctx) })
+}

--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -1,6 +1,7 @@
 package payouts
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/big"
@@ -72,7 +73,7 @@ func NewBlockUnlocker(cfg *UnlockerConfig, backend *storage.RedisClient, network
 	return u
 }
 
-func (u *BlockUnlocker) Start() {
+func (u *BlockUnlocker) Start(ctx context.Context) {
 	log.Println("Starting block unlocker")
 	intv := util.MustParseDuration(u.config.Interval)
 	timer := time.NewTimer(intv)
@@ -83,16 +84,18 @@ func (u *BlockUnlocker) Start() {
 	u.unlockAndCreditMiners()
 	timer.Reset(intv)
 
-	go func() {
-		for {
-			select {
-			case <-timer.C:
-				u.unlockPendingBlocks()
-				u.unlockAndCreditMiners()
-				timer.Reset(intv)
-			}
+	for {
+		select {
+		case <-timer.C:
+			u.unlockPendingBlocks()
+			u.unlockAndCreditMiners()
+			timer.Reset(intv)
+		case <-ctx.Done():
+			log.Println("Stopping block unlocker")
+			timer.Stop()
+			return
 		}
-	}()
+	}
 }
 
 type UnlockResult struct {


### PR DESCRIPTION
## What

The pool blocked forever on a never-receiving channel (`<-quit`) and had no signal handling, so it relied on the default signal disposition to die. This adds a real graceful shutdown.

## Changes

- **`main.go`**: `signal.NotifyContext(SIGINT, SIGTERM)`. The **block unlocker** and **payouts processor** (the balance-mutating modules) run under a `sync.WaitGroup` and are drained — allowed to finish their current cycle — before the process exits `0`. A second signal terminates immediately. The proxy/API network servers are torn down on exit (graceful connection draining is a possible follow-up).
- **`payouts`**: `BlockUnlocker.Start` / `PayoutsProcessor.Start` now take a `context.Context` and return when it's cancelled, instead of spawning an unstoppable background goroutine.

## Verification

Ran the built binary (unlocker enabled) and sent it `SIGTERM`:

```
Shutting down; waiting for unlocker/payouts to finish the current cycle...
Stopping block unlocker
Shutdown complete
EXIT_CODE=0
```

Clean exit 0 (was a hard kill before). `go build`, `go vet`, `go test ./payouts/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
