### PR TITLE
http: fix broken error responses in the API and proxy

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -259,13 +259,13 @@ func (s *ApiServer) AccountIndex(w http.ResponseWriter, r *http.Request) {
 	// Refresh stats if stale
 	if !ok || reply.updatedAt < now-cacheIntv {
 		exist, err := s.backend.IsMinerExists(login)
-		if !exist {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			log.Printf("Failed to fetch stats from backend: %v", err)
+			return
+		}
+		if !exist {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+const testAddr = "0x0000000000000000000000000000000000000000"
+
+func newTestServer(endpoint string) *ApiServer {
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: endpoint}, "test-api")
+	return NewApiServer(&ApiConfig{
+		StatsCollectInterval: "5s",
+		HashrateWindow:       "30m",
+		HashrateLargeWindow:  "3h",
+		Payments:             30,
+	}, backend)
+}
+
+func accountRequest(login string) *http.Request {
+	req := httptest.NewRequest("GET", "/api/accounts/"+login, nil)
+	return mux.SetURLVars(req, map[string]string{"login": login})
+}
+
+// A backend error must surface as 500, not be masked as a 404.
+func TestAccountIndexBackendError(t *testing.T) {
+	s := newTestServer("127.0.0.1:1") // unreachable Redis -> IsMinerExists errors
+	rec := httptest.NewRecorder()
+	s.AccountIndex(rec, accountRequest(testAddr))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (a backend error must not become 404)", rec.Code)
+	}
+}
+
+// A miner that does not exist, with a healthy backend, is a genuine 404.
+func TestAccountIndexNotFound(t *testing.T) {
+	s := newTestServer("127.0.0.1:6379")
+	rec := httptest.NewRecorder()
+	s.AccountIndex(rec, accountRequest(testAddr))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -289,8 +289,9 @@ func (cs *Session) sendError(id json.RawMessage, reply *ErrorReply) error {
 }
 
 func (s *ProxyServer) writeError(w http.ResponseWriter, status int, msg string) {
-	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	io.WriteString(w, msg)
 }
 
 func (s *ProxyServer) currentBlockTemplate() *BlockTemplate {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// writeError must set the Content-Type before WriteHeader (so it isn't dropped)
+// and write the message to the body.
+func TestWriteError(t *testing.T) {
+	s := &ProxyServer{}
+	rec := httptest.NewRecorder()
+
+	s.writeError(rec, 405, "rpc: POST method required")
+
+	if rec.Code != 405 {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain", ct)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "POST method required") {
+		t.Errorf("body = %q, must contain the error message", body)
+	}
+}


### PR DESCRIPTION
## What

Fix two broken HTTP error responses.

### api — `AccountIndex` masked backend errors as 404

`IsMinerExists` returns `(false, err)` on a Redis error, and the handler checked `!exist` before `err`, so any backend failure was returned as `404 Not Found`. The error is now checked first → `500` for backend errors, `404` only for genuinely missing miners.

### proxy — `writeError` produced an empty, mistyped response

`writeError` called `WriteHeader` before `Header().Set(...)` (so `Content-Type` was silently dropped) and never wrote `msg` to the body. It now sets the header, writes the status, then the body.

## Tests

First tests for the `api` and `proxy` packages:
- `TestWriteError`: status, `Content-Type`, body.
- `TestAccountIndexBackendError`: a backend error yields `500`, not `404`.
- `TestAccountIndexNotFound`: a missing miner yields `404`.

Both fixes were confirmed by running the tests against the pre-fix code (they fail) and after (they pass). No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
