### PR TITLE
payouts: auto-recover the block unlocker from transient errors

### DIFF
--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -41,11 +41,21 @@ var big8 = big.NewInt(8)
 var homesteadReward = math.MustParseBig256("5000000000000000000")
 
 type BlockUnlocker struct {
-	config   *UnlockerConfig
-	backend  *storage.RedisClient
-	rpc      *rpc.RPCClient
-	halt     bool
-	lastFail error
+	config      *UnlockerConfig
+	backend     *storage.RedisClient
+	rpc         unlockerRPC
+	halt        bool
+	lastFail    error
+	failsInARow int
+}
+
+// unlockerRPC is the subset of *rpc.RPCClient the unlocker uses. Declaring it
+// as an interface lets tests inject a client that fails on demand.
+type unlockerRPC interface {
+	GetPendingBlock() (*rpc.GetBlockReplyPart, error)
+	GetBlockByHeight(height int64) (*rpc.GetBlockReply, error)
+	GetUncleByBlockNumberAndIndex(height int64, index int) (*rpc.GetBlockReply, error)
+	GetTxReceipt(hash string) (*rpc.TxReceipt, error)
 }
 
 func NewBlockUnlocker(cfg *UnlockerConfig, backend *storage.RedisClient, network *string) *BlockUnlocker {
@@ -73,6 +83,11 @@ func NewBlockUnlocker(cfg *UnlockerConfig, backend *storage.RedisClient, network
 	return u
 }
 
+// maxUnlockFailsInARow re-suspends the unlocker after this many consecutive
+// failed cycles, so transient node/Redis blips self-heal but a persistently
+// wedged unlocker still surfaces and stops instead of retrying forever.
+const maxUnlockFailsInARow = 60
+
 func (u *BlockUnlocker) Start(ctx context.Context) {
 	log.Println("Starting block unlocker")
 	intv := util.MustParseDuration(u.config.Interval)
@@ -80,21 +95,43 @@ func (u *BlockUnlocker) Start(ctx context.Context) {
 	log.Printf("Set block unlock interval to %v", intv)
 
 	// Immediately unlock after start
-	u.unlockPendingBlocks()
-	u.unlockAndCreditMiners()
+	u.runCycle()
 	timer.Reset(intv)
 
 	for {
 		select {
 		case <-timer.C:
-			u.unlockPendingBlocks()
-			u.unlockAndCreditMiners()
+			u.runCycle()
 			timer.Reset(intv)
 		case <-ctx.Done():
 			log.Println("Stopping block unlocker")
 			timer.Stop()
 			return
 		}
+	}
+}
+
+// runCycle runs one unlock pass, recovering from a previous transient failure
+// unless too many cycles have failed in a row. Retrying is safe because each
+// block is credited and removed from the scanned zset in the SAME Redis
+// transaction (see storage.writeImmatureBlock / writeMaturedBlock), so a
+// re-scan after a failed cycle never re-credits an already-processed block.
+func (u *BlockUnlocker) runCycle() {
+	if u.halt {
+		if u.failsInARow >= maxUnlockFailsInARow {
+			log.Printf("Block unlocking suspended after %d consecutive failures; restart required. Last error: %v", u.failsInARow, u.lastFail)
+			return
+		}
+		u.halt = false
+	}
+
+	u.unlockPendingBlocks()
+	u.unlockAndCreditMiners()
+
+	if u.halt {
+		u.failsInARow++
+	} else {
+		u.failsInARow = 0
 	}
 }
 

--- a/payouts/unlocker_recovery_test.go
+++ b/payouts/unlocker_recovery_test.go
@@ -1,0 +1,93 @@
+package payouts
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/etclabscore/open-etc-pool/rpc"
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+// fakeUnlockerRPC lets a test fail GetPendingBlock on demand. GetPendingBlock is
+// the first RPC of a cycle, so failing it exercises the halt/recover path
+// without reaching Redis.
+type fakeUnlockerRPC struct {
+	pendingErr error
+}
+
+func (f *fakeUnlockerRPC) GetPendingBlock() (*rpc.GetBlockReplyPart, error) {
+	if f.pendingErr != nil {
+		return nil, f.pendingErr
+	}
+	return &rpc.GetBlockReplyPart{Number: "0x1"}, nil
+}
+
+func (f *fakeUnlockerRPC) GetBlockByHeight(int64) (*rpc.GetBlockReply, error) { return nil, nil }
+
+func (f *fakeUnlockerRPC) GetUncleByBlockNumberAndIndex(int64, int) (*rpc.GetBlockReply, error) {
+	return nil, nil
+}
+
+func (f *fakeUnlockerRPC) GetTxReceipt(string) (*rpc.TxReceipt, error) { return nil, nil }
+
+func newTestUnlocker(rpcClient unlockerRPC) *BlockUnlocker {
+	network := "classic"
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, "test-unlock-recover")
+	u := NewBlockUnlocker(&UnlockerConfig{
+		Interval:      "1h",
+		Depth:         120,
+		ImmatureDepth: 20,
+		Daemon:        "http://127.0.0.1:1",
+		Timeout:       "1s",
+	}, backend, &network)
+	u.rpc = rpcClient
+	return u
+}
+
+// A transient RPC error suspends the cycle, but the next cycle recovers once the
+// node is reachable again.
+func TestUnlockerRecoversFromTransientError(t *testing.T) {
+	fake := &fakeUnlockerRPC{}
+	u := newTestUnlocker(fake)
+
+	fake.pendingErr = errors.New("node unreachable")
+	u.runCycle()
+	if !u.halt {
+		t.Fatal("halt must be set after a failing cycle")
+	}
+	if u.failsInARow != 1 {
+		t.Fatalf("failsInARow = %d, want 1", u.failsInARow)
+	}
+
+	fake.pendingErr = nil // node is back
+	u.runCycle()
+	if u.halt {
+		t.Fatal("halt must clear after a successful cycle")
+	}
+	if u.failsInARow != 0 {
+		t.Fatalf("failsInARow = %d, want 0", u.failsInARow)
+	}
+}
+
+// After too many consecutive failures the unlocker re-latches: it stops retrying
+// (a restart is required) instead of looping forever on a wedged node.
+func TestUnlockerRelatchesAfterPersistentFailure(t *testing.T) {
+	fake := &fakeUnlockerRPC{pendingErr: errors.New("wedged")}
+	u := newTestUnlocker(fake)
+
+	for i := 0; i < maxUnlockFailsInARow; i++ {
+		u.runCycle()
+	}
+	if u.failsInARow != maxUnlockFailsInARow {
+		t.Fatalf("failsInARow = %d, want %d", u.failsInARow, maxUnlockFailsInARow)
+	}
+
+	// The next cycle is latched: it neither runs nor recovers.
+	u.runCycle()
+	if !u.halt {
+		t.Fatal("must stay halted after the failure threshold")
+	}
+	if u.failsInARow != maxUnlockFailsInARow {
+		t.Fatalf("a latched cycle must not run; failsInARow = %d, want %d", u.failsInARow, maxUnlockFailsInARow)
+	}
+}

--- a/storage/idempotency_test.go
+++ b/storage/idempotency_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"math/big"
+	"testing"
+)
+
+// The unlocker's cycle is safe to retry because a block is credited AND removed
+// from the scanned zset in the same atomic transaction: after crediting, a
+// re-scan finds nothing, so the credit can't be repeated on a retry. Note the
+// immature-balance HIncrBy is itself unconditional — the safety comes from the
+// set removal being part of the same EXEC, not from the credit log's HSetNX.
+func TestUnlockerCreditIsAtomicWithSetRemoval(t *testing.T) {
+	reset()
+
+	r.WriteShare("0xaa", "rig1", []string{"0x1", "0xp1", "0xm1"}, 100, 500, 0)
+	r.WriteBlock("0xaa", "rig1", []string{"0x2", "0xp2", "0xm2"}, 100, 5000, 500, 0)
+
+	candidates, _ := r.GetCandidates(1000)
+	if len(candidates) != 1 {
+		t.Fatalf("need one candidate, got %d", len(candidates))
+	}
+	block := candidates[0]
+	block.Hash = "0xhash"
+	block.Reward = big.NewInt(1000000000000000000)
+	rewards := map[string]int64{"0xaa": 100}
+
+	// Immature: crediting and removing the candidate are one transaction.
+	if err := r.WriteImmatureBlock(block, rewards); err != nil {
+		t.Fatalf("WriteImmatureBlock: %v", err)
+	}
+	if c, _ := r.GetCandidates(1000); len(c) != 0 {
+		t.Fatal("candidate must be gone from the scanned set after crediting")
+	}
+	if got := minerImmature(t, "0xaa"); got != 100 {
+		t.Fatalf("immature = %d, want 100", got)
+	}
+	// A retried cycle re-scans candidates and finds nothing -> no double credit.
+	if c, _ := r.GetCandidates(1000); len(c) != 0 {
+		t.Fatal("re-scan must be empty (this is what makes a retry safe)")
+	}
+
+	// Matured: the same invariant holds for immature -> matured.
+	immature, _ := r.GetImmatureBlocks(1000)
+	if len(immature) != 1 {
+		t.Fatalf("need one immature block, got %d", len(immature))
+	}
+	imblock := immature[0]
+	imblock.Reward = big.NewInt(1000000000000000000)
+	if err := r.WriteMaturedBlock(imblock, rewards); err != nil {
+		t.Fatalf("WriteMaturedBlock: %v", err)
+	}
+	if im, _ := r.GetImmatureBlocks(1000); len(im) != 0 {
+		t.Fatal("block must be gone from immature after maturing")
+	}
+	if bal, _ := r.GetBalance("0xaa"); bal != 100 {
+		t.Fatalf("balance = %d, want 100", bal)
+	}
+	if got := minerImmature(t, "0xaa"); got != 0 {
+		t.Fatalf("immature after maturing = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## What

The block unlocker latched `halt` permanently on any error, so a brief node or Redis outage suspended unlocking until a process restart. This makes transient failures self-heal, while still stopping on a persistent failure.

## Changes

- **`runCycle`** clears `halt` at the start of each cycle, but re-latches after `maxUnlockFailsInARow` consecutive failures — a wedged unlocker (e.g. a deterministically failing candidate) stops instead of retrying forever.
- The unlocker's RPC dependency is now an interface (`unlockerRPC`) so tests can inject failures. `*rpc.RPCClient` satisfies it; no runtime change.

## Why retrying is safe

A block is credited **and** removed from the scanned zset in the **same** Redis transaction (`storage.writeImmatureBlock` / `writeMaturedBlock`), so a re-scan after a failed cycle never re-credits an already-processed block. (The immature-balance `HIncrBy` is unconditional — the safety comes from the atomic set removal, not from the credit log's `HSetNX`.)

## Tests

- `storage/TestUnlockerCreditIsAtomicWithSetRemoval`: verifies the credit and the set-removal are atomic — after crediting, a re-scan of candidates/immature is empty.
- `payouts/TestUnlockerRecoversFromTransientError`: a transient RPC error suspends one cycle; the next recovers.
- `payouts/TestUnlockerRelatchesAfterPersistentFailure`: after the failure threshold the unlocker re-latches.

The payouts processor keeps its permanent `halt` for the payment-critical (post-mutation) error paths; relaxing its two safe pre-mutation error sites will be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
