### PR TITLE
payouts: retry the payer on pre-payment errors instead of halting

### DIFF
--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -46,9 +46,19 @@ func (self PayoutsConfig) GasPriceHex() string {
 type PayoutsProcessor struct {
 	config   *PayoutsConfig
 	backend  *storage.RedisClient
-	rpc      *rpc.RPCClient
+	rpc      payerRPC
 	halt     bool
 	lastFail error
+}
+
+// payerRPC is the subset of *rpc.RPCClient the payouts processor uses, as an
+// interface so tests can inject failures.
+type payerRPC interface {
+	GetBalance(address string) (*big.Int, error)
+	Sign(from string, s string) (string, error)
+	GetPeerCount() (int64, error)
+	SendTransaction(from, to, gas, gasPrice, value string, autoGas bool) (string, error)
+	GetTxReceipt(hash string) (*rpc.TxReceipt, error)
 }
 
 func NewPayoutsProcessor(cfg *PayoutsConfig, backend *storage.RedisClient) *PayoutsProcessor {
@@ -140,18 +150,17 @@ func (u *PayoutsProcessor) process() {
 			break
 		}
 
-		// Check if we have enough funds
+		// Check if we have enough funds. These two checks are before any state
+		// mutation, so a transient failure retries next cycle instead of
+		// permanently halting payouts.
 		poolBalance, err := u.rpc.GetBalance(u.config.Address)
 		if err != nil {
-			u.halt = true
-			u.lastFail = err
+			log.Printf("Unable to get pool balance from node, retrying next cycle: %v", err)
 			break
 		}
 		if poolBalance.Cmp(amountInWei) < 0 {
-			err := fmt.Errorf("Not enough balance for payment, need %s Wei, pool has %s Wei",
+			log.Printf("Not enough pool balance for payment, need %s Wei, pool has %s Wei; retrying next cycle",
 				amountInWei.String(), poolBalance.String())
-			u.halt = true
-			u.lastFail = err
 			break
 		}
 

--- a/payouts/payer_test.go
+++ b/payouts/payer_test.go
@@ -1,0 +1,86 @@
+package payouts
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/etclabscore/open-etc-pool/rpc"
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+type fakePayerRPC struct {
+	peers          int64
+	signErr        error
+	poolBalance    *big.Int
+	poolBalanceErr error
+	sendTxErr      error
+}
+
+func (f *fakePayerRPC) GetPeerCount() (int64, error)         { return f.peers, nil }
+func (f *fakePayerRPC) Sign(from, s string) (string, error)  { return "0xsig", f.signErr }
+func (f *fakePayerRPC) GetBalance(a string) (*big.Int, error) { return f.poolBalance, f.poolBalanceErr }
+func (f *fakePayerRPC) SendTransaction(from, to, gas, gasPrice, value string, autoGas bool) (string, error) {
+	return "0xtxhash", f.sendTxErr
+}
+func (f *fakePayerRPC) GetTxReceipt(hash string) (*rpc.TxReceipt, error) { return nil, nil }
+
+const payerPrefix = "test-payer"
+
+func newTestPayer(t *testing.T, fake payerRPC) *PayoutsProcessor {
+	t.Helper()
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, payerPrefix)
+
+	ctx := context.Background()
+	if keys, _ := backend.Client().Keys(ctx, payerPrefix+":*").Result(); len(keys) > 0 {
+		backend.Client().Del(ctx, keys...)
+	}
+	// One payee above the payout threshold.
+	if err := backend.Client().HSet(ctx, payerPrefix+":miners:0xaa", "balance", "1000").Err(); err != nil {
+		t.Fatalf("seed miner: %v", err)
+	}
+
+	u := NewPayoutsProcessor(&PayoutsConfig{
+		Interval:     "1h",
+		RequirePeers: 1,
+		Threshold:    100,
+		Address:      "0x0000000000000000000000000000000000000001",
+		Gas:          "21000",
+		GasPrice:     "50000000000",
+		Daemon:       "http://127.0.0.1:1",
+		Timeout:      "1s",
+	}, backend)
+	u.rpc = fake
+	return u
+}
+
+// A transient error BEFORE any state mutation (fetching the pool balance) must
+// retry next cycle, not permanently halt payouts.
+func TestPayerRetriesOnPreMutationError(t *testing.T) {
+	fake := &fakePayerRPC{peers: 25, poolBalanceErr: errors.New("node unreachable")}
+	u := newTestPayer(t, fake)
+
+	u.process()
+
+	if u.halt {
+		t.Error("a pre-mutation RPC error must not halt payouts")
+	}
+}
+
+// A failure AFTER state has been mutated (the transaction was sent) must halt
+// and require manual resolution, to avoid double-paying.
+func TestPayerHaltsOnPostMutationError(t *testing.T) {
+	fake := &fakePayerRPC{
+		peers:       25,
+		poolBalance: big.NewInt(1000000000000000000), // 1 ETC in Wei, plenty
+		sendTxErr:   errors.New("broadcast failed"),
+	}
+	u := newTestPayer(t, fake)
+
+	u.process()
+
+	if !u.halt {
+		t.Error("a post-mutation error (SendTransaction) must halt payouts (safety latch)")
+	}
+}


### PR DESCRIPTION
## What

The payouts processor latched `halt` permanently on any error, so a transient node/Redis blip suspended payouts until a process restart. This relaxes only the error sites that occur **before any state is mutated**.

## Changes

- Relaxed two pre-mutation sites in `process()` — fetching the pool balance and the "not enough balance" check — to **log and retry next cycle** instead of halting.
- Kept the permanent `halt` on the four **post-mutation** sites (`LockPayouts`, `UpdateBalance`, `SendTransaction`, `WritePayment`): once a payout has debited a balance or broadcast a transaction, retrying could double-pay or lose a miner's balance, so an operator must resolve it (`RESOLVE_PAYOUT=1`).
- The RPC dependency is now an interface (`payerRPC`) so tests can inject failures. `*rpc.RPCClient` satisfies it; no runtime change.

## Tests

- `TestPayerRetriesOnPreMutationError`: a pool-balance RPC error does **not** set `halt`.
- `TestPayerHaltsOnPostMutationError`: a `SendTransaction` error **does** set `halt`.

Follows the unlocker recovery change; together they let both payout modules ride out transient node/Redis outages while preserving payment safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
