### PR TITLE
proxy: fix hasher init data race; snapshot sessions for broadcast

### DIFF
--- a/proxy/miner.go
+++ b/proxy/miner.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/etclabscore/go-etchash"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,19 +14,32 @@ import (
 var ecip1099FBlockClassic uint64 = 11700000 // classic mainnet
 var ecip1099FBlockMordor uint64 = 2520000   // mordor
 
-var hasher *etchash.Etchash = nil
+var (
+	hasher     *etchash.Etchash
+	hasherOnce sync.Once
+)
+
+// getHasher builds the Etchash verifier once, safely under concurrent share
+// submissions (this was previously an unsynchronized nil-check + assignment on
+// a package global — a data race).
+func getHasher(network string) *etchash.Etchash {
+	hasherOnce.Do(func() {
+		switch network {
+		case "classic":
+			hasher = etchash.New(&ecip1099FBlockClassic, nil)
+		case "mordor":
+			hasher = etchash.New(&ecip1099FBlockMordor, nil)
+		default:
+			log.Printf("Unknown network configuration %s", network)
+		}
+	})
+	return hasher
+}
 
 func (s *ProxyServer) processShare(login, id, ip string, t *BlockTemplate, params []string) (bool, bool) {
-	if hasher == nil {
-		if s.config.Network == "classic" {
-			hasher = etchash.New(&ecip1099FBlockClassic, nil)
-		} else if s.config.Network == "mordor" {
-			hasher = etchash.New(&ecip1099FBlockMordor, nil)
-		} else {
-			// unknown network
-			log.Printf("Unknown network configuration %s", s.config.Network)
-			return false, false
-		}
+	verifier := getHasher(s.config.Network)
+	if verifier == nil {
+		return false, false
 	}
 	nonceHex := params[0]
 	hashNoNonce := params[1]
@@ -55,11 +69,11 @@ func (s *ProxyServer) processShare(login, id, ip string, t *BlockTemplate, param
 		mixDigest:   common.HexToHash(mixDigest),
 	}
 
-	if !hasher.Verify(share) {
+	if !verifier.Verify(share) {
 		return false, false
 	}
 
-	if hasher.Verify(block) {
+	if verifier.Verify(block) {
 		ok, err := s.rpc().SubmitBlock(params)
 		if err != nil {
 			log.Printf("Block submission failure at height %v for %v: %v", h.height, t.Header, err)

--- a/proxy/miner_test.go
+++ b/proxy/miner_test.go
@@ -1,0 +1,32 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/etclabscore/go-etchash"
+)
+
+// getHasher must be safe under concurrent first use — the previous code did an
+// unsynchronized nil-check + assignment on a package global. Run with -race.
+func TestGetHasherConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	got := make([]*etchash.Etchash, 16)
+	for i := range got {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			got[i] = getHasher("classic")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, h := range got {
+		if h == nil {
+			t.Fatalf("goroutine %d got a nil hasher", i)
+		}
+		if h != got[0] {
+			t.Fatalf("goroutine %d got a different hasher instance", i)
+		}
+	}
+}

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -191,17 +191,25 @@ func (s *ProxyServer) broadcastNewJobs() {
 	}
 	reply := []string{t.Header, t.Seed, s.diff}
 
+	// Snapshot the sessions under the read lock, then broadcast outside it: the
+	// broadcast does slow network I/O, and its per-session goroutines call
+	// removeSession (write lock), so holding the read lock throughout would
+	// block register/removeSession for the whole broadcast.
 	s.sessionsMu.RLock()
-	defer s.sessionsMu.RUnlock()
+	sessions := make([]*Session, 0, len(s.sessions))
+	for m := range s.sessions {
+		sessions = append(sessions, m)
+	}
+	s.sessionsMu.RUnlock()
 
-	count := len(s.sessions)
+	count := len(sessions)
 	log.Printf("Broadcasting new job to %v stratum miners", count)
 
 	start := time.Now()
 	bcast := make(chan int, 1024)
 	n := 0
 
-	for m, _ := range s.sessions {
+	for _, m := range sessions {
 		n++
 		bcast <- n
 


### PR DESCRIPTION
## Changes

### `miner.go` — data race on the shared Etchash verifier

The verifier was a package global built lazily with an unsynchronized `if hasher == nil { hasher = ... }`, so concurrent first shares raced on it (read + write with no lock). It's now built once with `sync.Once` (`getHasher`).

### `stratum.go` — read lock held for the whole broadcast

`broadcastNewJobs` held `sessionsMu.RLock()` for the entire broadcast, which does slow network I/O and whose per-session goroutines call `removeSession` (write lock). Holding the read lock throughout blocks `registerSession`/`removeSession` for the whole broadcast. It now snapshots the sessions under the lock and broadcasts outside it. Behavior is unchanged.

## Test

`TestGetHasherConcurrent` calls `getHasher` from many goroutines under `-race`. Verified it reports `DATA RACE` against the pre-fix (unsynchronized) code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
