### PR TITLE
proxy: end-to-end mining test over HTTP and Stratum; policy: accept shares when banning is disabled

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -233,6 +233,15 @@ func (s *PolicyServer) ApplySharePolicy(ip string, validShare bool) bool {
 		x.InvalidShares++
 	}
 
+	// The invalid-share ratio below only drives banning; when banning is off it
+	// can never ban, only reject the caller's response, so accept every share
+	// here (mirrors ApplyLimitPolicy's !Limits.Enabled short-circuit). Kept after
+	// the counters above so the Limits reward still applies when banning is off.
+	if !s.config.Banning.Enabled {
+		x.Unlock()
+		return true
+	}
+
 	totalShares := x.ValidShares + x.InvalidShares
 	if totalShares < s.config.Banning.CheckThreshold {
 		x.Unlock()

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,0 +1,73 @@
+package policy
+
+import "testing"
+
+// newTestServer builds a PolicyServer without Start() so the share-policy
+// decision can be exercised without a Redis backend or the background workers.
+func newTestServer(cfg *Config) *PolicyServer {
+	return &PolicyServer{config: cfg, stats: make(map[string]*Stats)}
+}
+
+// With banning disabled, ApplySharePolicy must accept every share — even under
+// the degenerate CheckThreshold=0/InvalidPercent=0 config, where the ratio
+// branch would otherwise reject the very first valid share (ratio 0 >= 0).
+func TestApplySharePolicyBanningDisabledAcceptsShares(t *testing.T) {
+	s := newTestServer(&Config{
+		Banning: Banning{Enabled: false, CheckThreshold: 0, InvalidPercent: 0},
+	})
+	ip := "10.0.0.1"
+
+	if !s.ApplySharePolicy(ip, true) {
+		t.Fatal("valid share rejected with banning disabled")
+	}
+	if !s.ApplySharePolicy(ip, false) {
+		t.Fatal("invalid share rejected with banning disabled (nothing to ban)")
+	}
+	if s.IsBanned(ip) {
+		t.Fatal("client banned with banning disabled")
+	}
+}
+
+// With banning enabled, a high invalid-share ratio past the check threshold must
+// still reject the share and ban the client — the disabled-guard must not have
+// disturbed this path.
+func TestApplySharePolicyBansOnHighInvalidRatio(t *testing.T) {
+	s := newTestServer(&Config{
+		Banning: Banning{Enabled: true, CheckThreshold: 2, InvalidPercent: 50},
+	})
+	ip := "10.0.0.2"
+
+	if !s.ApplySharePolicy(ip, true) {
+		t.Fatal("first share below threshold should be accepted")
+	}
+	// Second share crosses the threshold with a 1:1 invalid ratio (100% >= 50%).
+	if s.ApplySharePolicy(ip, false) {
+		t.Fatal("share above the invalid-ratio threshold should be rejected")
+	}
+	if !s.IsBanned(ip) {
+		t.Fatal("client should be banned after crossing the invalid-ratio threshold")
+	}
+}
+
+// The banning-disabled guard must sit after the counter block so the Limits
+// reward still applies: a valid share with Limits on / banning off must grow the
+// connection allowance by LimitJump. This pins the placement — hoisting the
+// guard to the top of ApplySharePolicy would skip incrLimit and fail here.
+func TestApplySharePolicyValidShareRewardsLimitWhenBanningDisabled(t *testing.T) {
+	s := newTestServer(&Config{
+		Banning: Banning{Enabled: false},
+		Limits:  Limits{Enabled: true, Limit: 10, LimitJump: 5},
+	})
+	ip := "10.0.0.3"
+
+	x := s.Get(ip)
+	if x.ConnLimit != 10 {
+		t.Fatalf("initial ConnLimit = %d, want 10 (Limits.Limit)", x.ConnLimit)
+	}
+	if !s.ApplySharePolicy(ip, true) {
+		t.Fatal("valid share rejected with banning disabled")
+	}
+	if x.ConnLimit != 15 {
+		t.Fatalf("ConnLimit = %d after a valid share, want 15 (10 + LimitJump)", x.ConnLimit)
+	}
+}

--- a/proxy/e2e_test.go
+++ b/proxy/e2e_test.go
@@ -1,0 +1,256 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/etclabscore/go-etchash"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/etclabscore/open-etc-pool/policy"
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+// End-to-end mining test: a mock node serves fixed low-difficulty work, the real
+// pool runs against it over real sockets, and a test-miner computes a valid
+// Etchash share (with the same go-etchash library the pool verifies with) and
+// submits it through BOTH ingress protocols — HTTP getwork and Stratum. It
+// asserts each share is accepted and lands in Redis.
+//
+// It fits GitHub Actions because there is no real node (mocked) and the PoW is
+// trivial: block height 1 → epoch 0 (~small cache), pool difficulty 1 → any
+// nonce is a valid share. Requires the Redis service (skips if unavailable).
+
+const (
+	e2eHeader      = "0x" + "abababababababababababababababababababababababababababababababab"
+	e2eSeed        = "0x" + "0000000000000000000000000000000000000000000000000000000000000000"
+	e2eWorkTarget  = "0x01" // huge network difficulty -> shares, never blocks
+	e2eBlockNumber = "0x1"  // height 1 => epoch 0
+	e2eLogin       = "0x00000000000000000000000000000000000000aa"
+	e2eHTTPAddr    = "127.0.0.1:39888"
+	e2eStratumAddr = "127.0.0.1:39008"
+	e2eFBlock      = uint64(11700000) // ecip1099FBlockClassic
+	e2ePrefix      = "teste2e"
+)
+
+// startMockNode serves just enough JSON-RPC for the pool: getWork (also the
+// health check), the pending block, and submitWork.
+func startMockNode() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+
+		var result interface{}
+		switch req.Method {
+		case "eth_getWork":
+			result = []string{e2eHeader, e2eSeed, e2eWorkTarget}
+		case "eth_getBlockByNumber":
+			result = map[string]string{"number": e2eBlockNumber, "difficulty": "0x1"}
+		case "eth_submitWork":
+			result = true
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 0, "jsonrpc": "2.0", "result": result})
+	}))
+}
+
+func e2eConfig(upstreamURL string) *Config {
+	return &Config{
+		Name:    "test",
+		Network: "classic",
+		Coin:    e2ePrefix,
+		Redis:   storage.Config{Endpoint: "127.0.0.1:6379"},
+		Upstream: []Upstream{
+			{Name: "mock", Url: upstreamURL, Timeout: "10s"},
+		},
+		UpstreamCheckInterval: "5s",
+		Proxy: Proxy{
+			Enabled:              true,
+			Listen:               e2eHTTPAddr,
+			LimitHeadersSize:     1 << 10,
+			LimitBodySize:        1 << 20,
+			BlockRefreshInterval: "1s",
+			StateUpdateInterval:  "3s",
+			Difficulty:           1, // any nonce is a valid share
+			HashrateExpiration:   "3h",
+			HealthCheck:          true,
+			MaxFails:             100,
+			Stratum: Stratum{
+				Enabled: true,
+				Listen:  e2eStratumAddr,
+				Timeout: "60s",
+				MaxConn: 128,
+			},
+			Policy: policy.Config{
+				Workers:         8,
+				ResetInterval:   "60m",
+				RefreshInterval: "60m",
+				Banning:         policy.Banning{Enabled: false},
+				Limits:          policy.Limits{Enabled: false, Grace: "5m"},
+			},
+		},
+	}
+}
+
+func waitForPort(t *testing.T, addr string) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			c.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("listener %s never came up", addr)
+}
+
+func TestEndToEndMining(t *testing.T) {
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, e2ePrefix)
+	if _, err := backend.Check(); err != nil {
+		t.Skipf("Redis not available, skipping e2e: %v", err)
+	}
+	ctx := context.Background()
+	if keys, _ := backend.Client().Keys(ctx, e2ePrefix+":*").Result(); len(keys) > 0 {
+		backend.Client().Del(ctx, keys...)
+	}
+
+	node := startMockNode()
+	defer node.Close()
+
+	proxy := NewProxy(e2eConfig(node.URL), backend) // fetches template + starts stratum listener
+	go proxy.Start()                                // HTTP listener
+	waitForPort(t, e2eHTTPAddr)
+	waitForPort(t, e2eStratumAddr)
+
+	// The test-miner uses the same library and epoch the pool verifies with.
+	miner := etchash.New(func() *uint64 { f := e2eFBlock; return &f }(), nil)
+	compute := func(nonce uint64) (nonceHex, mixHex string) {
+		mix, _ := miner.Compute(1, common.HexToHash(e2eHeader), nonce)
+		return fmt.Sprintf("0x%016x", nonce), strings.ToLower(mix.Hex())
+	}
+
+	// --- Ingress 1: HTTP getwork ---
+	httpURL := "http://" + e2eHTTPAddr + "/" + e2eLogin + "/rig1"
+	work := httpGetWork(t, httpURL)
+	if len(work) < 3 || work[0] != e2eHeader {
+		t.Fatalf("HTTP getwork returned unexpected work: %v", work)
+	}
+	nonceHex, mixHex := compute(0)
+	if !httpSubmit(t, httpURL, nonceHex, e2eHeader, mixHex) {
+		t.Fatal("HTTP getwork share was rejected")
+	}
+	t.Log("HTTP getwork share accepted")
+
+	// --- Ingress 2: Stratum ---
+	nonceHex, mixHex = compute(1) // a different nonce so it isn't a duplicate
+	if !stratumMine(t, e2eStratumAddr, nonceHex, mixHex) {
+		t.Fatal("Stratum share was rejected")
+	}
+	t.Log("Stratum share accepted")
+
+	// --- Both shares must have reached Redis ---
+	stats, err := backend.GetMinerStats(e2eLogin, 30)
+	if err != nil {
+		t.Fatalf("GetMinerStats: %v", err)
+	}
+	if rs, _ := stats["roundShares"].(int64); rs != 2 {
+		t.Fatalf("round shares in Redis = %v, want 2 (one per ingress)", stats["roundShares"])
+	}
+}
+
+func httpGetWork(t *testing.T, url string) []string {
+	t.Helper()
+	raw := httpRPC(t, url, "eth_getWork", []string{})
+	var work []string
+	if err := json.Unmarshal(raw, &work); err != nil {
+		t.Fatalf("decode getWork result %s: %v", raw, err)
+	}
+	return work
+}
+
+func httpSubmit(t *testing.T, url, nonce, header, mix string) bool {
+	t.Helper()
+	raw := httpRPC(t, url, "eth_submitWork", []string{nonce, header, mix})
+	var ok bool
+	_ = json.Unmarshal(raw, &ok)
+	return ok
+}
+
+func httpRPC(t *testing.T, url, method string, params interface{}) json.RawMessage {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", method, err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Result json.RawMessage `json:"result"`
+		Error  interface{}     `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode %s response: %v", method, err)
+	}
+	if out.Error != nil {
+		t.Fatalf("%s returned error: %v", method, out.Error)
+	}
+	return out.Result
+}
+
+func stratumMine(t *testing.T, addr, nonce, mix string) bool {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("stratum dial: %v", err)
+	}
+	defer conn.Close()
+	br := bufio.NewReader(conn)
+
+	call := func(id int, method string, params []string) json.RawMessage {
+		req, _ := json.Marshal(map[string]interface{}{"id": id, "method": method, "params": params, "worker": "rig1"})
+		conn.SetDeadline(time.Now().Add(60 * time.Second))
+		if _, err := conn.Write(append(req, '\n')); err != nil {
+			t.Fatalf("stratum write %s: %v", method, err)
+		}
+		line, err := br.ReadBytes('\n')
+		if err != nil {
+			t.Fatalf("stratum read %s: %v", method, err)
+		}
+		var out struct {
+			Result json.RawMessage `json:"result"`
+			Error  interface{}     `json:"error"`
+		}
+		_ = json.Unmarshal(line, &out)
+		if out.Error != nil {
+			t.Fatalf("stratum %s error: %v", method, out.Error)
+		}
+		return out.Result
+	}
+
+	var loggedIn bool
+	_ = json.Unmarshal(call(1, "eth_submitLogin", []string{e2eLogin, "x"}), &loggedIn)
+	if !loggedIn {
+		t.Fatal("stratum login failed")
+	}
+	work := call(2, "eth_getWork", nil)
+	var w []string
+	if err := json.Unmarshal(work, &w); err != nil || len(w) < 3 || w[0] != e2eHeader {
+		t.Fatalf("stratum getWork unexpected: %s", work)
+	}
+	var ok bool
+	_ = json.Unmarshal(call(3, "eth_submitWork", []string{nonce, e2eHeader, mix}), &ok)
+	return ok
+}


### PR DESCRIPTION
Two commits: a policy correctness fix and the end-to-end mining test that exercises it.

## `policy`: accept shares when banning is disabled

`ApplySharePolicy` computed the invalid-share ratio and could return `false` regardless of `Banning.Enabled`. `forceBan` is a no-op when banning is off, but the caller (`handleSubmitRPC`) treats a `false` return as `"High rate of invalid shares"` and rejects the response of an otherwise valid share. With `checkThreshold` and `invalidPercent` left at `0`, the ratio branch (`0 >= 0`) rejected the very first valid share.

The fix short-circuits to `true` once the counters are updated when banning is disabled — mirroring `ApplyLimitPolicy`'s `!Limits.Enabled` guard, and placed after the counter block so the Limits reward still applies. `policy_test.go` covers both the disabled path and the enabled high-ratio ban.

## `proxy`: end-to-end mining test over HTTP and Stratum

A real socket-level test that a share can be **mined and accepted through both ingress protocols** — HTTP getwork and Stratum.

- A **mock upstream** (`httptest`) serves fixed `eth_getWork` (block height 1 → epoch 0, so a small Etchash cache; pool difficulty 1 → any nonce is a valid share) and accepts `eth_submitWork`.
- The **real proxy** runs against it (`NewProxy` + `Start`) with its HTTP and Stratum listeners on local ports.
- A **test-miner** computes a valid Etchash share with `go-etchash` (`Light.Compute`) — the same library and epoch the pool verifies with — and submits it over **HTTP getwork** (`eth_getWork` → mine → `eth_submitWork`) and over **Stratum** (`eth_submitLogin` → `eth_getWork` → `eth_submitWork`).
- Asserts each share is accepted and that both land in Redis (`round shares == 2`).

The test runs with `banning` disabled and zero thresholds, so it also guards against a regression of the policy fix above.

## CI

No real node (mocked) and trivial PoW, so it runs in a few seconds on a GitHub runner using the existing Redis service. It **skips** when Redis is unavailable, so `go test ./proxy/` still passes locally without Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
