### PR TITLE
payouts: surface backend errors on lock and clear a stuck lock

### DIFF
--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -296,13 +296,16 @@ func (self PayoutsProcessor) resolvePayouts() {
 			}
 			log.Printf("Credited %v Shannon back to %s", v.Amount, v.Address)
 		}
-		err := self.backend.UnlockPayouts()
-		if err != nil {
-			log.Println("Failed to unlock payouts:", err)
-			return
-		}
 	} else {
 		log.Println("No pending payments to resolve")
+	}
+
+	// Always clear the lock. A payout can leave it set with no pending payments
+	// (e.g. it crashed between locking and recording the debit); without clearing
+	// it here that stuck lock would block every future payout with no way out.
+	if err := self.backend.UnlockPayouts(); err != nil {
+		log.Println("Failed to unlock payouts:", err)
+		return
 	}
 
 	if self.config.BgSave {

--- a/payouts/resolve_test.go
+++ b/payouts/resolve_test.go
@@ -1,0 +1,40 @@
+package payouts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+// A payout can leave the lock set with no pending-payment records (e.g. it
+// crashed between locking and recording the debit). resolvePayouts must clear
+// that stuck lock; otherwise every future payout stays blocked with no way to
+// recover short of manual Redis surgery.
+func TestResolvePayoutsClearsStuckLockWithNoPendingPayments(t *testing.T) {
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, payerPrefix)
+	if _, err := backend.Check(); err != nil {
+		t.Skipf("Redis not available, skipping: %v", err)
+	}
+	ctx := context.Background()
+	if keys, _ := backend.Client().Keys(ctx, payerPrefix+":*").Result(); len(keys) > 0 {
+		backend.Client().Del(ctx, keys...)
+	}
+
+	if err := backend.LockPayouts("0xaa", 5); err != nil {
+		t.Fatalf("LockPayouts: %v", err)
+	}
+	if locked, _ := backend.IsPayoutsLocked(); !locked {
+		t.Fatal("payouts should be locked after LockPayouts")
+	}
+	if p := backend.GetPendingPayments(); len(p) != 0 {
+		t.Fatalf("expected no pending payments, got %d", len(p))
+	}
+
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend}
+	proc.resolvePayouts()
+
+	if locked, _ := backend.IsPayoutsLocked(); locked {
+		t.Fatal("resolvePayouts must clear the lock even with no pending payments")
+	}
+}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -344,8 +344,11 @@ func (r *RedisClient) GetBalance(login string) (int64, error) {
 
 func (r *RedisClient) LockPayouts(login string, amount int64) error {
 	key := r.formatKey("payments", "lock")
-	result := r.client.SetNX(ctx, key, join(login, amount), 0).Val()
-	if !result {
+	acquired, err := r.client.SetNX(ctx, key, join(login, amount), 0).Result()
+	if err != nil {
+		return err
+	}
+	if !acquired {
 		return fmt.Errorf("Unable to acquire lock '%s'", key)
 	}
 	return nil

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/redis/go-redis/v9"
@@ -332,5 +333,42 @@ func reset() {
 	keys := r.client.Keys(ctx, r.prefix+":*").Val()
 	for _, k := range keys {
 		r.client.Del(ctx, k)
+	}
+}
+
+func TestLockPayoutsContention(t *testing.T) {
+	reset()
+
+	if err := r.LockPayouts("0xaa", 5); err != nil {
+		t.Fatalf("first lock should succeed: %v", err)
+	}
+	locked, err := r.IsPayoutsLocked()
+	if err != nil || !locked {
+		t.Fatalf("payouts should be locked: locked=%v err=%v", locked, err)
+	}
+	// A second lock while the first is held is genuine contention, not a
+	// backend failure.
+	if err := r.LockPayouts("0xbb", 7); err == nil {
+		t.Fatal("second lock should fail while the first is held")
+	}
+	if err := r.UnlockPayouts(); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+	if locked, _ := r.IsPayoutsLocked(); locked {
+		t.Fatal("payouts should be unlocked after UnlockPayouts")
+	}
+}
+
+func TestLockPayoutsSurfacesBackendError(t *testing.T) {
+	// Pointed at a closed port, LockPayouts must return the real connection
+	// error, not the "Unable to acquire lock" contention message that swallowing
+	// the SetNX error with .Val() would have produced.
+	down := NewRedisClient(&Config{Endpoint: "127.0.0.1:1"}, prefix)
+	err := down.LockPayouts("0xaa", 5)
+	if err == nil {
+		t.Fatal("expected an error when the backend is unreachable")
+	}
+	if strings.Contains(err.Error(), "Unable to acquire lock") {
+		t.Fatalf("backend error masked as lock contention: %v", err)
 	}
 }


### PR DESCRIPTION
Two related correctness fixes to the payouts lock lifecycle.

## `LockPayouts` masked backend errors as lock contention

`LockPayouts` read `SetNX(...).Val()`, which discards the error. A Redis failure returns the zero value (`false`), so the function reported `"Unable to acquire lock"` — indistinguishable from a genuinely held lock. The payer then treats it the same as contention, so a transient backend blip is diagnosed (and logged) as if another payout were in progress.

Fix: read `.Result()` and return the backend error, so a transient failure surfaces as itself instead of masquerading as a held lock.

## `resolvePayouts` could not clear a stuck lock

`resolvePayouts` only called `UnlockPayouts` inside the `len(payments) > 0` branch. A payout that acquired the lock but recorded **no** pending payment (e.g. it crashed between locking and the debit) left the lock set with nothing to credit back — and `resolvePayouts` logged `"Payouts unlocked"` while never actually clearing it. Every future payout then stays blocked (`IsPayoutsLocked` → `"Unable to start payouts because they are locked"`) with no way to recover short of editing Redis by hand.

Fix: always clear the lock after crediting back (a mid-rollback failure still returns early and leaves it set, as before). `UnlockPayouts` is a no-op when nothing is locked, so this is safe in the normal path.

## Tests

- `TestLockPayoutsContention` — a second lock while the first is held returns an error; unlock releases it.
- `TestLockPayoutsSurfacesBackendError` — against a closed port, the returned error is the real connection failure, not the contention message (fails on the pre-fix `.Val()` code).
- `TestResolvePayoutsClearsStuckLockWithNoPendingPayments` — a stuck lock with zero pending payments is cleared (fails on the pre-fix code). Skips when Redis is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
