### PR TITLE
proxy: expose pool Prometheus metrics

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
           # Hash of the module dependencies. Recompute after go.mod/go.sum
           # changes: set to pkgs.lib.fakeHash, run `nix build .#default`, and
           # copy the expected hash from the error.
-          vendorHash = "sha256-bpWpheF7goaqnz87o6qa9nhB9m1i1j6ZRl10B7sTg50=";
+          vendorHash = "sha256-PRJY75NLDADFkz+VxVO2v4t4Q3cDN3k9QaRcKoC5UyY=";
 
           subPackages = [ "." ];
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,72 @@
+// Package metrics declares the pool's Prometheus collectors. They register with
+// the default registry, so the existing /metrics endpoint (main.go) exposes them
+// alongside the Go runtime and process telemetry.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Share outcome labels for ShareOutcomes.
+const (
+	ShareValid     = "valid"
+	ShareInvalid   = "invalid"
+	ShareStale     = "stale"
+	ShareDuplicate = "duplicate"
+	ShareMalformed = "malformed"
+)
+
+// Block submission result labels for BlockSubmissions.
+const (
+	SubmitAccepted = "accepted"
+	SubmitRejected = "rejected"
+	SubmitError    = "error"
+)
+
+var (
+	// ShareOutcomes counts submitted shares by outcome. The buckets are mutually
+	// exclusive: a share is malformed, stale, a duplicate, invalid, or valid.
+	ShareOutcomes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "oep_shares_total",
+		Help: "Submitted shares by outcome (valid, invalid, stale, duplicate, malformed).",
+	}, []string{"status"})
+
+	// BlocksFound counts valid blocks the pool found and the upstream accepted.
+	BlocksFound = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "oep_blocks_found_total",
+		Help: "Valid blocks found by the pool and accepted by the upstream node.",
+	})
+
+	// BlockSubmissions counts block submissions to the upstream by result.
+	BlockSubmissions = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "oep_block_submissions_total",
+		Help: "Block submissions to the upstream node by result (accepted, rejected, error).",
+	}, []string{"result"})
+
+	// StratumSessions tracks the number of currently connected Stratum miners.
+	StratumSessions = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "oep_stratum_sessions",
+		Help: "Currently connected Stratum miners.",
+	})
+
+	// UpstreamHealthy reflects each upstream node's health from the latest check.
+	UpstreamHealthy = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "oep_upstream_healthy",
+		Help: "Upstream node health from the latest check (1 = healthy, 0 = sick).",
+	}, []string{"url"})
+)
+
+// ShareOutcome records a single share outcome. Use the Share* constants.
+func ShareOutcome(status string) {
+	ShareOutcomes.WithLabelValues(status).Inc()
+}
+
+// SetUpstreamHealthy records an upstream's health as a 0/1 gauge.
+func SetUpstreamHealthy(url string, healthy bool) {
+	v := 0.0
+	if healthy {
+		v = 1.0
+	}
+	UpstreamHealthy.WithLabelValues(url).Set(v)
+}

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/etclabscore/open-etc-pool/metrics"
 	"github.com/etclabscore/open-etc-pool/rpc"
 	"github.com/etclabscore/open-etc-pool/util"
 )
@@ -59,12 +60,14 @@ func (s *ProxyServer) handleSubmitRPC(cs *Session, login, id string, params []st
 	}
 	if len(params) != 3 {
 		s.policy.ApplyMalformedPolicy(cs.ip)
+		metrics.ShareOutcome(metrics.ShareMalformed)
 		log.Printf("Malformed params from %s@%s %v", login, cs.ip, params)
 		return false, &ErrorReply{Code: -1, Message: "Invalid params"}
 	}
 
 	if !noncePattern.MatchString(params[0]) || !hashPattern.MatchString(params[1]) || !hashPattern.MatchString(params[2]) {
 		s.policy.ApplyMalformedPolicy(cs.ip)
+		metrics.ShareOutcome(metrics.ShareMalformed)
 		log.Printf("Malformed PoW result from %s@%s %v", login, cs.ip, params)
 		return false, &ErrorReply{Code: -1, Message: "Malformed PoW result"}
 	}

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -1,0 +1,151 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/etclabscore/go-etchash"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/etclabscore/open-etc-pool/metrics"
+	"github.com/etclabscore/open-etc-pool/storage"
+)
+
+// These tests drive processShare through each outcome and assert the Prometheus
+// counters move by exactly one. They need the Redis service (they skip without
+// it). Counters are global, so the assertions use before/after deltas.
+//
+// The mock reports height 8: it stays in Etchash epoch 0 (small, fast cache),
+// but avoids checkPoWExist's height-8 sweep underflowing at tiny heights, which
+// would otherwise drop the entry and hide duplicates.
+
+const metricsHeight = uint64(8)
+
+func shareCount(status string) float64 {
+	return testutil.ToFloat64(metrics.ShareOutcomes.WithLabelValues(status))
+}
+
+func assertShareDelta(t *testing.T, status string, want float64, fn func()) {
+	t.Helper()
+	before := shareCount(status)
+	fn()
+	if got := shareCount(status) - before; got != want {
+		t.Fatalf("shares{status=%q} delta = %v, want %v", status, got, want)
+	}
+}
+
+func flushKeys(b *storage.RedisClient, prefix string) {
+	ctx := context.Background()
+	if keys, _ := b.Client().Keys(ctx, prefix+":*").Result(); len(keys) > 0 {
+		b.Client().Del(ctx, keys...)
+	}
+}
+
+func mineShare(t *testing.T, nonce uint64) (nonceHex, mixHex string) {
+	t.Helper()
+	m := etchash.New(func() *uint64 { f := e2eFBlock; return &f }(), nil)
+	mix, _ := m.Compute(metricsHeight, common.HexToHash(e2eHeader), nonce)
+	return fmt.Sprintf("0x%016x", nonce), strings.ToLower(mix.Hex())
+}
+
+// startMetricsMock serves fixed work at height 8 with the given getWork target.
+// A huge target (e2eWorkTarget) yields shares only; a tiny difficulty (0xff..ff
+// target) makes a valid share also a valid block.
+func startMetricsMock(target string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+
+		var result interface{}
+		switch req.Method {
+		case "eth_getWork":
+			result = []string{e2eHeader, e2eSeed, target}
+		case "eth_getBlockByNumber":
+			result = map[string]string{"number": "0x8", "difficulty": "0x1"}
+		case "eth_submitWork":
+			result = true
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 0, "jsonrpc": "2.0", "result": result})
+	}))
+}
+
+func newMetricsProxy(t *testing.T, coin, target string) (*ProxyServer, *BlockTemplate) {
+	t.Helper()
+	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, coin)
+	if _, err := backend.Check(); err != nil {
+		t.Skipf("Redis not available, skipping: %v", err)
+	}
+	flushKeys(backend, coin)
+
+	node := startMetricsMock(target)
+	t.Cleanup(node.Close)
+
+	cfg := e2eConfig(node.URL)
+	cfg.Coin = coin
+	cfg.Proxy.Stratum.Enabled = false // no listeners needed; call processShare directly
+	proxy := NewProxy(cfg, backend)
+	tpl := proxy.currentBlockTemplate()
+	if tpl == nil || tpl.Header != e2eHeader {
+		t.Fatalf("unexpected block template: %+v", tpl)
+	}
+	return proxy, tpl
+}
+
+func TestShareOutcomeMetrics(t *testing.T) {
+	proxy, tpl := newMetricsProxy(t, "testmetrics", e2eWorkTarget)
+	const ip = "127.0.0.1"
+
+	// Valid share.
+	n0, m0 := mineShare(t, 0)
+	assertShareDelta(t, metrics.ShareValid, 1, func() {
+		proxy.processShare(e2eLogin, "rig1", ip, tpl, []string{n0, e2eHeader, m0})
+	})
+
+	// Duplicate — the same nonce again.
+	assertShareDelta(t, metrics.ShareDuplicate, 1, func() {
+		proxy.processShare(e2eLogin, "rig1", ip, tpl, []string{n0, e2eHeader, m0})
+	})
+
+	// Stale — a header the template doesn't know.
+	n1, m1 := mineShare(t, 1)
+	otherHeader := "0x" + strings.Repeat("cd", 32)
+	assertShareDelta(t, metrics.ShareStale, 1, func() {
+		proxy.processShare(e2eLogin, "rig1", ip, tpl, []string{n1, otherHeader, m1})
+	})
+
+	// Invalid — right header, wrong mix digest.
+	zeroMix := "0x" + strings.Repeat("00", 32)
+	assertShareDelta(t, metrics.ShareInvalid, 1, func() {
+		proxy.processShare(e2eLogin, "rig1", ip, tpl, []string{"0x0000000000000009", e2eHeader, zeroMix})
+	})
+}
+
+func TestBlockFoundMetrics(t *testing.T) {
+	easyTarget := "0x" + strings.Repeat("f", 64) // network difficulty ~1
+	proxy, tpl := newMetricsProxy(t, "testmetricsblk", easyTarget)
+
+	beforeBlocks := testutil.ToFloat64(metrics.BlocksFound)
+	beforeAccepted := testutil.ToFloat64(metrics.BlockSubmissions.WithLabelValues(metrics.SubmitAccepted))
+
+	n0, m0 := mineShare(t, 0)
+	exist, valid := proxy.processShare(e2eLogin, "rig1", "127.0.0.1", tpl, []string{n0, e2eHeader, m0})
+	if exist || !valid {
+		t.Fatalf("processShare = (exist=%v, valid=%v), want (false, true)", exist, valid)
+	}
+	if got := testutil.ToFloat64(metrics.BlocksFound) - beforeBlocks; got != 1 {
+		t.Fatalf("blocks_found delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.BlockSubmissions.WithLabelValues(metrics.SubmitAccepted)) - beforeAccepted; got != 1 {
+		t.Fatalf("block_submissions{accepted} delta = %v, want 1", got)
+	}
+}

--- a/proxy/miner.go
+++ b/proxy/miner.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/etclabscore/go-etchash"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/etclabscore/open-etc-pool/metrics"
 )
 
 var ecip1099FBlockClassic uint64 = 11700000 // classic mainnet
@@ -50,6 +52,7 @@ func (s *ProxyServer) processShare(login, id, ip string, t *BlockTemplate, param
 	h, ok := t.headers[hashNoNonce]
 	if !ok {
 		log.Printf("Stale share from %v@%v", login, ip)
+		metrics.ShareOutcome(metrics.ShareStale)
 		return false, false
 	}
 
@@ -70,20 +73,25 @@ func (s *ProxyServer) processShare(login, id, ip string, t *BlockTemplate, param
 	}
 
 	if !verifier.Verify(share) {
+		metrics.ShareOutcome(metrics.ShareInvalid)
 		return false, false
 	}
 
 	if verifier.Verify(block) {
 		ok, err := s.rpc().SubmitBlock(params)
 		if err != nil {
+			metrics.BlockSubmissions.WithLabelValues(metrics.SubmitError).Inc()
 			log.Printf("Block submission failure at height %v for %v: %v", h.height, t.Header, err)
 		} else if !ok {
+			metrics.BlockSubmissions.WithLabelValues(metrics.SubmitRejected).Inc()
 			log.Printf("Block rejected at height %v for %v", h.height, t.Header)
 			return false, false
 		} else {
+			metrics.BlockSubmissions.WithLabelValues(metrics.SubmitAccepted).Inc()
 			s.fetchBlockTemplate()
 			exist, err := s.backend.WriteBlock(login, id, params, shareDiff, h.diff.Int64(), h.height, s.hashrateExpiration)
 			if exist {
+				metrics.ShareOutcome(metrics.ShareDuplicate)
 				return true, false
 			}
 			if err != nil {
@@ -91,16 +99,19 @@ func (s *ProxyServer) processShare(login, id, ip string, t *BlockTemplate, param
 			} else {
 				log.Printf("Inserted block %v to backend", h.height)
 			}
+			metrics.BlocksFound.Inc()
 			log.Printf("Block found by miner %v@%v at height %d", login, ip, h.height)
 		}
 	} else {
 		exist, err := s.backend.WriteShare(login, id, params, shareDiff, h.height, s.hashrateExpiration)
 		if exist {
+			metrics.ShareOutcome(metrics.ShareDuplicate)
 			return true, false
 		}
 		if err != nil {
 			log.Println("Failed to insert share data into backend:", err)
 		}
 	}
+	metrics.ShareOutcome(metrics.ShareValid)
 	return false, true
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/etclabscore/open-etc-pool/metrics"
 	"github.com/etclabscore/open-etc-pool/policy"
 	"github.com/etclabscore/open-etc-pool/rpc"
 	"github.com/etclabscore/open-etc-pool/storage"
@@ -158,7 +159,9 @@ func (s *ProxyServer) checkUpstreams() {
 	backup := false
 
 	for i, v := range s.upstreams {
-		if v.Check() && !backup {
+		ok := v.Check()
+		metrics.SetUpstreamHealthy(v.Url, ok)
+		if ok && !backup {
 			candidate = int32(i)
 			backup = true
 		}

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/etclabscore/open-etc-pool/metrics"
 	"github.com/etclabscore/open-etc-pool/util"
 )
 
@@ -176,12 +177,14 @@ func (s *ProxyServer) registerSession(cs *Session) {
 	s.sessionsMu.Lock()
 	defer s.sessionsMu.Unlock()
 	s.sessions[cs] = struct{}{}
+	metrics.StratumSessions.Set(float64(len(s.sessions)))
 }
 
 func (s *ProxyServer) removeSession(cs *Session) {
 	s.sessionsMu.Lock()
 	defer s.sessionsMu.Unlock()
 	delete(s.sessions, cs)
+	metrics.StratumSessions.Set(float64(len(s.sessions)))
 }
 
 func (s *ProxyServer) broadcastNewJobs() {


### PR DESCRIPTION
Adds pool-specific Prometheus collectors on the existing `/metrics` endpoint, which until now exposed only Go runtime and process telemetry (from the New Relic → Prometheus swap).

## Metrics

| Metric | Type | Labels |
|---|---|---|
| `oep_shares_total` | counter | `status` = valid, invalid, stale, duplicate, malformed |
| `oep_blocks_found_total` | counter | — |
| `oep_block_submissions_total` | counter | `result` = accepted, rejected, error |
| `oep_stratum_sessions` | gauge | — |
| `oep_upstream_healthy` | gauge | `url` |

Enough for a Grafana dashboard covering share throughput/quality, block-find rate and submission outcomes, connected miners, and per-upstream node health.

## Instrumentation

- **Shares & blocks** at the decision points: `processShare` (stale / invalid / duplicate / valid, block found, submission result) and `handleSubmitRPC` (malformed). The share buckets are mutually exclusive.
- **Upstream health**: `checkUpstreams` records each node's latest check as 0/1.
- **Stratum sessions**: `registerSession` / `removeSession` set the gauge to the live session count (set-to-len, so it stays correct even if a session is removed twice).

## Tests

`proxy/metrics_test.go` drives `processShare` through each share outcome and a found block (with a trivial-difficulty mock so a valid share is also a block), asserting each counter moves by exactly one. Skips without Redis, like the e2e test.

No new module dependencies — `client_golang` already backs `/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
