### PR TITLE
payouts: fail loudly instead of silently truncating a reward

### DIFF
--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -512,7 +512,10 @@ func (u *BlockUnlocker) calculateRewards(block *storage.BlockData) (*big.Rat, *b
 		return nil, nil, nil, nil, err
 	}
 
-	rewards := calculateRewardsForShares(shares, block.TotalShares, minersProfit)
+	rewards, err := calculateRewardsForShares(shares, block.TotalShares, minersProfit)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
 	if block.ExtraReward != nil {
 		extraReward := new(big.Rat).SetInt(block.ExtraReward)
@@ -522,21 +525,29 @@ func (u *BlockUnlocker) calculateRewards(block *storage.BlockData) (*big.Rat, *b
 
 	if len(u.config.PoolFeeAddress) != 0 {
 		address := strings.ToLower(u.config.PoolFeeAddress)
-		rewards[address] += weiToShannonInt64(poolProfit)
+		poolFee, err := weiToShannonInt64(poolProfit)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		rewards[address] += poolFee
 	}
 
 	return revenue, minersProfit, poolProfit, rewards, nil
 }
 
-func calculateRewardsForShares(shares map[string]int64, total int64, reward *big.Rat) map[string]int64 {
+func calculateRewardsForShares(shares map[string]int64, total int64, reward *big.Rat) (map[string]int64, error) {
 	rewards := make(map[string]int64)
 
 	for login, n := range shares {
 		percent := big.NewRat(n, total)
 		workerReward := new(big.Rat).Mul(reward, percent)
-		rewards[login] += weiToShannonInt64(workerReward)
+		value, err := weiToShannonInt64(workerReward)
+		if err != nil {
+			return nil, fmt.Errorf("worker %s: %w", login, err)
+		}
+		rewards[login] += value
 	}
-	return rewards
+	return rewards, nil
 }
 
 // Returns new value after fee deduction and fee value.
@@ -546,11 +557,18 @@ func chargeFee(value *big.Rat, fee float64) (*big.Rat, *big.Rat) {
 	return new(big.Rat).Sub(value, feeValue), feeValue
 }
 
-func weiToShannonInt64(wei *big.Rat) int64 {
+func weiToShannonInt64(wei *big.Rat) (int64, error) {
 	shannon := new(big.Rat).SetInt(util.Shannon)
 	inShannon := new(big.Rat).Quo(wei, shannon)
-	value, _ := strconv.ParseInt(inShannon.FloatString(0), 10, 64)
-	return value
+	str := inShannon.FloatString(0)
+	// Guard the conversion: with ETC amounts a reward always fits int64 Shannon,
+	// but if it ever didn't, ParseInt would clamp and silently corrupt a balance.
+	// Fail loudly instead so the caller halts the round rather than crediting it.
+	value, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("reward %s Shannon does not fit in int64: %w", str, err)
+	}
+	return value, nil
 }
 
 // GetRewardByEra gets a block reward at disinflation rate.

--- a/payouts/unlocker_test.go
+++ b/payouts/unlocker_test.go
@@ -1,11 +1,14 @@
 package payouts
 
 import (
-	"github.com/etclabscore/open-etc-pool/rpc"
-	"github.com/etclabscore/open-etc-pool/storage"
+	"math"
 	"math/big"
 	"os"
 	"testing"
+
+	"github.com/etclabscore/open-etc-pool/rpc"
+	"github.com/etclabscore/open-etc-pool/storage"
+	"github.com/etclabscore/open-etc-pool/util"
 )
 
 func TestMain(m *testing.M) {
@@ -18,7 +21,10 @@ func TestCalculateRewards(t *testing.T) {
 	expectedRewards := map[string]int64{"0x0": 4877996431, "0x1": 97559929, "0x2": 24389982, "0x3": 48780, "0x4": 4878}
 	totalShares := int64(1025011)
 
-	rewards := calculateRewardsForShares(shares, totalShares, blockReward)
+	rewards, err := calculateRewardsForShares(shares, totalShares, blockReward)
+	if err != nil {
+		t.Fatalf("calculateRewardsForShares: %v", err)
+	}
 	expectedTotalAmount := int64(5000000000)
 
 	totalAmount := int64(0)
@@ -57,11 +63,36 @@ func TestWeiToShannonInt64(t *testing.T) {
 	origWei, _ := new(big.Rat).SetString("1000000000000000000")
 	shannon := int64(1000000000)
 
-	if weiToShannonInt64(wei) != shannon {
+	got, err := weiToShannonInt64(wei)
+	if err != nil {
+		t.Fatalf("weiToShannonInt64: %v", err)
+	}
+	if got != shannon {
 		t.Error("Must convert to Shannon")
 	}
 	if wei.Cmp(origWei) != 0 {
 		t.Error("Must charge original value")
+	}
+}
+
+func TestWeiToShannonInt64Overflow(t *testing.T) {
+	// (MaxInt64 + 1) Shannon, expressed in Wei, cannot fit int64 Shannon.
+	overflowShannon := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	wei := new(big.Rat).SetInt(new(big.Int).Mul(overflowShannon, util.Shannon))
+
+	if _, err := weiToShannonInt64(wei); err == nil {
+		t.Fatal("expected an overflow error for a reward exceeding int64 Shannon")
+	}
+}
+
+func TestCalculateRewardsForSharesOverflow(t *testing.T) {
+	// A block reward so large a single share's cut overflows int64 Shannon must
+	// surface an error rather than silently clamping a miner's balance.
+	overflowShannon := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	reward := new(big.Rat).SetInt(new(big.Int).Mul(overflowShannon, util.Shannon))
+
+	if _, err := calculateRewardsForShares(map[string]int64{"0xaa": 1}, 1, reward); err == nil {
+		t.Fatal("expected an overflow error from calculateRewardsForShares")
 	}
 }
 


### PR DESCRIPTION
Hardens the one money conversion that could silently corrupt a balance.

## The issue

`weiToShannonInt64` converted a Wei `big.Rat` reward to int64 Shannon with `strconv.ParseInt(..., 10, 64)` and **discarded the error**. On overflow `ParseInt` clamps to `MaxInt64` — so a reward that didn't fit int64 Shannon would silently credit a miner an astronomical balance instead of failing.

## The fix

Return the error and propagate it through `calculateRewardsForShares` → `calculateRewards`. Both unlock paths already treat a reward-calculation error as "skip this round" (they log `Failed to calculate rewards` and leave the block for the next cycle), so an overflow now halts safely instead of writing a corrupted credit.

## Why not big.Int in storage?

Considered and deliberately **not** done: every balance is stored in **Shannon (Gwei)**, and all of ETC's supply is ~2.1e17 Shannon — far under int64's 9.2e18 ceiling. Full block rewards live in `big.Int`/`big.Rat` right up to this final conversion, and Redis `HINCRBY` already errors on int64 overflow. Moving stored balances to big.Int would **lose `HINCRBY`'s atomicity** (turning atomic credits into racy read-modify-write) and break on-disk compatibility — worse, for an overflow that can't occur with ETC amounts. Guarding the conversion boundary delivers the actual overflow safety without those costs.

## Tests

`TestWeiToShannonInt64Overflow` and `TestCalculateRewardsForSharesOverflow` assert a reward exceeding int64 Shannon surfaces an error rather than clamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
