### PR TITLE
payouts: don't double-pay when resolving an interrupted payout

### DIFF
--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -193,6 +193,17 @@ func (u *PayoutsProcessor) process() {
 			break
 		}
 
+		// Record the broadcast tx hash before WritePayment, so that a crash here
+		// leaves enough state for resolvePayouts to recognise this payout as
+		// already sent and not credit the balance back (which would double-pay).
+		err = u.backend.SetPendingPaymentTx(login, amount, txHash)
+		if err != nil {
+			log.Printf("Failed to record pending tx %s for %s: %v", txHash, login, err)
+			u.halt = true
+			u.lastFail = err
+			break
+		}
+
 		// Log transaction hash
 		err = u.backend.WritePayment(login, txHash, amount)
 		if err != nil {
@@ -286,15 +297,43 @@ func (self PayoutsProcessor) resolvePayouts() {
 	payments := self.backend.GetPendingPayments()
 
 	if len(payments) > 0 {
-		log.Printf("Will credit back following balances:\n%s", formatPendingPayments(payments))
+		log.Printf("Resolving %v pending payment(s):\n%s", len(payments), formatPendingPayments(payments))
 
 		for _, v := range payments {
-			err := self.backend.RollbackBalance(v.Address, v.Amount)
+			txHash, err := self.backend.GetPendingPaymentTx(v.Address, v.Amount)
 			if err != nil {
-				log.Printf("Failed to credit %v Shannon back to %s, error is: %v", v.Amount, v.Address, err)
+				log.Printf("Failed to read pending tx for %s, leaving it for manual resolution: %v", v.Address, err)
 				return
 			}
-			log.Printf("Credited %v Shannon back to %s", v.Amount, v.Address)
+
+			// No tx was ever broadcast (crash before or during send), so the
+			// payout never left the pool and the balance can be credited back.
+			if txHash == "" {
+				if err := self.backend.RollbackBalance(v.Address, v.Amount); err != nil {
+					log.Printf("Failed to credit %v Shannon back to %s: %v", v.Amount, v.Address, err)
+					return
+				}
+				log.Printf("Credited %v Shannon back to %s (no payout tx was broadcast)", v.Amount, v.Address)
+				continue
+			}
+
+			// A payout tx was broadcast. Only credit back if it provably reverted
+			// on-chain; when it succeeded, is still pending, or can't be checked,
+			// treat it as paid so an already-sent payout is never double-paid.
+			receipt, err := self.rpc.GetTxReceipt(txHash)
+			if err == nil && receipt != nil && receipt.Confirmed() && !receipt.Successful() {
+				if err := self.backend.RollbackBalance(v.Address, v.Amount); err != nil {
+					log.Printf("Failed to credit %v Shannon back to %s: %v", v.Amount, v.Address, err)
+					return
+				}
+				log.Printf("Credited %v Shannon back to %s (payout tx %s reverted on-chain)", v.Amount, v.Address, txHash)
+				continue
+			}
+			if err := self.backend.WritePayment(v.Address, txHash, v.Amount); err != nil {
+				log.Printf("Failed to record payment for %s: %v", v.Address, err)
+				return
+			}
+			log.Printf("Recorded %v Shannon to %s as paid (tx %s already broadcast); not crediting back", v.Amount, v.Address, txHash)
 		}
 	} else {
 		log.Println("No pending payments to resolve")

--- a/payouts/payer_test.go
+++ b/payouts/payer_test.go
@@ -16,6 +16,8 @@ type fakePayerRPC struct {
 	poolBalance    *big.Int
 	poolBalanceErr error
 	sendTxErr      error
+	receipt        *rpc.TxReceipt
+	receiptErr     error
 }
 
 func (f *fakePayerRPC) GetPeerCount() (int64, error)         { return f.peers, nil }
@@ -24,7 +26,7 @@ func (f *fakePayerRPC) GetBalance(a string) (*big.Int, error) { return f.poolBal
 func (f *fakePayerRPC) SendTransaction(from, to, gas, gasPrice, value string, autoGas bool) (string, error) {
 	return "0xtxhash", f.sendTxErr
 }
-func (f *fakePayerRPC) GetTxReceipt(hash string) (*rpc.TxReceipt, error) { return nil, nil }
+func (f *fakePayerRPC) GetTxReceipt(hash string) (*rpc.TxReceipt, error) { return f.receipt, f.receiptErr }
 
 const payerPrefix = "test-payer"
 

--- a/payouts/resolve_test.go
+++ b/payouts/resolve_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/redis/go-redis/v9"
+
+	"github.com/etclabscore/open-etc-pool/rpc"
 	"github.com/etclabscore/open-etc-pool/storage"
 )
 
-// A payout can leave the lock set with no pending-payment records (e.g. it
-// crashed between locking and recording the debit). resolvePayouts must clear
-// that stuck lock; otherwise every future payout stays blocked with no way to
-// recover short of manual Redis surgery.
-func TestResolvePayoutsClearsStuckLockWithNoPendingPayments(t *testing.T) {
+func resolveBackend(t *testing.T) *storage.RedisClient {
+	t.Helper()
 	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, payerPrefix)
 	if _, err := backend.Check(); err != nil {
 		t.Skipf("Redis not available, skipping: %v", err)
@@ -20,12 +20,51 @@ func TestResolvePayoutsClearsStuckLockWithNoPendingPayments(t *testing.T) {
 	if keys, _ := backend.Client().Keys(ctx, payerPrefix+":*").Result(); len(keys) > 0 {
 		backend.Client().Del(ctx, keys...)
 	}
+	return backend
+}
+
+// seedStuckPayout reproduces the state a payout leaves after it locks, debits the
+// balance, and (when txHash != "") broadcasts the tx, then crashes before
+// WritePayment records it.
+func seedStuckPayout(t *testing.T, backend *storage.RedisClient, login string, amount int64, txHash string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := backend.Client().HSet(ctx, payerPrefix+":miners:"+login, "balance", amount).Err(); err != nil {
+		t.Fatalf("seed balance: %v", err)
+	}
+	if err := backend.LockPayouts(login, amount); err != nil {
+		t.Fatalf("LockPayouts: %v", err)
+	}
+	if err := backend.UpdateBalance(login, amount); err != nil { // balance -> 0, pending -> amount
+		t.Fatalf("UpdateBalance: %v", err)
+	}
+	if txHash != "" {
+		if err := backend.SetPendingPaymentTx(login, amount, txHash); err != nil {
+			t.Fatalf("SetPendingPaymentTx: %v", err)
+		}
+	}
+}
+
+func minerField(t *testing.T, backend *storage.RedisClient, login, field string) int64 {
+	t.Helper()
+	v, err := backend.Client().HGet(context.Background(), payerPrefix+":miners:"+login, field).Int64()
+	if err == redis.Nil {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("HGet %s: %v", field, err)
+	}
+	return v
+}
+
+// A payout can leave the lock set with no pending-payment records (e.g. it
+// crashed between locking and recording the debit). resolvePayouts must clear
+// that stuck lock; otherwise every future payout stays blocked.
+func TestResolvePayoutsClearsStuckLockWithNoPendingPayments(t *testing.T) {
+	backend := resolveBackend(t)
 
 	if err := backend.LockPayouts("0xaa", 5); err != nil {
 		t.Fatalf("LockPayouts: %v", err)
-	}
-	if locked, _ := backend.IsPayoutsLocked(); !locked {
-		t.Fatal("payouts should be locked after LockPayouts")
 	}
 	if p := backend.GetPendingPayments(); len(p) != 0 {
 		t.Fatalf("expected no pending payments, got %d", len(p))
@@ -36,5 +75,71 @@ func TestResolvePayoutsClearsStuckLockWithNoPendingPayments(t *testing.T) {
 
 	if locked, _ := backend.IsPayoutsLocked(); locked {
 		t.Fatal("resolvePayouts must clear the lock even with no pending payments")
+	}
+}
+
+// A payout that never broadcast its tx (crash before/at send) leaves no tx hash;
+// the balance is safe to credit back.
+func TestResolvePayoutsCreditsBackWhenNeverBroadcast(t *testing.T) {
+	backend := resolveBackend(t)
+	const login, amount = "0xbb", int64(500)
+	seedStuckPayout(t, backend, login, amount, "")
+
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend, rpc: &fakePayerRPC{}}
+	proc.resolvePayouts()
+
+	if bal, _ := backend.GetBalance(login); bal != amount {
+		t.Fatalf("balance = %d, want %d credited back", bal, amount)
+	}
+	if p := backend.GetPendingPayments(); len(p) != 0 {
+		t.Fatalf("pending not cleared: %d", len(p))
+	}
+	if locked, _ := backend.IsPayoutsLocked(); locked {
+		t.Fatal("lock not cleared")
+	}
+}
+
+// A payout whose tx was already broadcast (tx hash recorded) must NOT be credited
+// back — that would double-pay. With the tx unverifiable/pending it is recorded
+// as paid.
+func TestResolvePayoutsDoesNotCreditBackAlreadyBroadcast(t *testing.T) {
+	backend := resolveBackend(t)
+	const login, amount = "0xcc", int64(700)
+	seedStuckPayout(t, backend, login, amount, "0xdeadbeef")
+
+	// nil receipt: tx not yet mined / unverifiable -> treat as paid, don't credit back.
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend, rpc: &fakePayerRPC{receipt: nil}}
+	proc.resolvePayouts()
+
+	if bal, _ := backend.GetBalance(login); bal != 0 {
+		t.Fatalf("balance = %d, want 0 (an already-sent payout must not be credited back)", bal)
+	}
+	if paid := minerField(t, backend, login, "paid"); paid != amount {
+		t.Fatalf("paid = %d, want %d (payout recorded as paid)", paid, amount)
+	}
+	if p := backend.GetPendingPayments(); len(p) != 0 {
+		t.Fatalf("pending not cleared: %d", len(p))
+	}
+	if locked, _ := backend.IsPayoutsLocked(); locked {
+		t.Fatal("lock not cleared")
+	}
+}
+
+// A payout whose tx was broadcast but provably reverted on-chain moved no value,
+// so the balance is credited back.
+func TestResolvePayoutsCreditsBackWhenTxReverted(t *testing.T) {
+	backend := resolveBackend(t)
+	const login, amount = "0xdd", int64(900)
+	seedStuckPayout(t, backend, login, amount, "0xreverted")
+
+	reverted := &rpc.TxReceipt{TxHash: "0xreverted", BlockHash: "0xblock", Status: "0x0"} // confirmed, failed
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend, rpc: &fakePayerRPC{receipt: reverted}}
+	proc.resolvePayouts()
+
+	if bal, _ := backend.GetBalance(login); bal != amount {
+		t.Fatalf("balance = %d, want %d credited back after a reverted payout", bal, amount)
+	}
+	if p := backend.GetPendingPayments(); len(p) != 0 {
+		t.Fatalf("pending not cleared: %d", len(p))
 	}
 }

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -414,9 +414,29 @@ func (r *RedisClient) RollbackBalance(login string, amount int64) error {
 		tx.HIncrBy(ctx, r.formatKey("finances"), "balance", amount)
 		tx.HIncrBy(ctx, r.formatKey("finances"), "pending", (amount * -1))
 		tx.ZRem(ctx, r.formatKey("payments", "pending"), join(login, amount))
+		tx.HDel(ctx, r.formatKey("payments", "pendingtx"), join(login, amount))
 		return nil
 	})
 	return err
+}
+
+// SetPendingPaymentTx records the broadcast transaction hash for the in-flight
+// pending payment (there is only ever one, guarded by the global payout lock).
+// It lets resolvePayouts distinguish an already-sent payout from one that never
+// left the pool, so a crash between broadcasting the tx and WritePayment cannot
+// be resolved by crediting the balance back and double-paying.
+func (r *RedisClient) SetPendingPaymentTx(login string, amount int64, txHash string) error {
+	return r.client.HSet(ctx, r.formatKey("payments", "pendingtx"), join(login, amount), txHash).Err()
+}
+
+// GetPendingPaymentTx returns the recorded broadcast tx hash for a pending
+// payment, or an empty string if none was recorded (the payout was never sent).
+func (r *RedisClient) GetPendingPaymentTx(login string, amount int64) (string, error) {
+	txHash, err := r.client.HGet(ctx, r.formatKey("payments", "pendingtx"), join(login, amount)).Result()
+	if err == redis.Nil {
+		return "", nil
+	}
+	return txHash, err
 }
 
 func (r *RedisClient) WritePayment(login, txHash string, amount int64) error {
@@ -430,6 +450,7 @@ func (r *RedisClient) WritePayment(login, txHash string, amount int64) error {
 		tx.ZAdd(ctx, r.formatKey("payments", "all"), redis.Z{Score: float64(ts), Member: join(txHash, login, amount)})
 		tx.ZAdd(ctx, r.formatKey("payments", login), redis.Z{Score: float64(ts), Member: join(txHash, amount)})
 		tx.ZRem(ctx, r.formatKey("payments", "pending"), join(login, amount))
+		tx.HDel(ctx, r.formatKey("payments", "pendingtx"), join(login, amount))
 		tx.Del(ctx, r.formatKey("payments", "lock"))
 		return nil
 	})


### PR DESCRIPTION
Fixes **H1** from the audit: `resolvePayouts` could re-pay an already-sent payout, losing pool funds.

## The bug

`process()` pays a miner as: `LockPayouts` → `UpdateBalance` (debit) → `SendTransaction` (broadcast on-chain) → `WritePayment` (record + unlock). The pending record was `login:amount` with **no tx hash**. If the process crashed between the broadcast and `WritePayment`, the pending entry survived with no way to know the tx had gone out. The operator's `RESOLVE_PAYOUT=1` tool (`resolvePayouts`) then credited every pending balance back **unconditionally** — so the miner, already paid on-chain, was over threshold again next cycle and **paid a second time**.

## The fix

Record the broadcast tx hash immediately after `SendTransaction`, before `WritePayment` (`SetPendingPaymentTx`). `resolvePayouts` now decides per pending payment:

- **No tx recorded** → the payout never left → credit the balance back (safe).
- **Tx recorded, provably reverted on-chain** (`GetTxReceipt` confirmed + failed) → no value moved → credit back.
- **Tx recorded, succeeded / still pending / unverifiable** → treat as paid; **never credit back** an already-sent payout.

`WritePayment` and `RollbackBalance` clear the pending-tx entry so it can't leak.

## Residual window (documented, not silently ignored)

A crash in the sub-millisecond window between `SendTransaction` returning and the `SetPendingPaymentTx` write still leaves a tx-less pending entry. This is far smaller than the previous window (the whole `WritePayment` transaction) and is the irreducible gap without on-chain nonce reconciliation. The conservative direction is preserved: the balance is debited before sending, so the failure mode is "operator verifies via the logged tx hash", never a silent double-pay in the common cases.

## Tests

`resolve_test.go` covers all three paths against live Redis (skips without it): credited back when never broadcast, **not** credited back when already broadcast (recorded as paid), credited back when the tx reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
