### PR TITLE
proxy: trust only the reverse proxy's X-Forwarded-For hop

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -186,9 +186,18 @@ func (s *ProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *ProxyServer) remoteAddr(r *http.Request) string {
 	if s.config.Proxy.BehindReverseProxy {
-		ip := r.Header.Get("X-Forwarded-For")
-		if len(ip) > 0 && net.ParseIP(ip) != nil {
-			return ip
+		// Trust only the rightmost X-Forwarded-For entry: it is the address our
+		// own reverse proxy appended for the peer that connected to it. Entries
+		// to the left are supplied by the client and therefore spoofable — using
+		// them lets a miner evade bans and, worse, drive the ipset ban of an
+		// arbitrary victim IP. This assumes a single trusted proxy that appends
+		// XFF (nginx's $proxy_add_x_forwarded_for).
+		if xff := r.Header.Get("X-Forwarded-For"); len(xff) > 0 {
+			parts := strings.Split(xff, ",")
+			ip := strings.TrimSpace(parts[len(parts)-1])
+			if net.ParseIP(ip) != nil {
+				return ip
+			}
 		}
 	}
 	ip, _, _ := net.SplitHostPort(r.RemoteAddr)

--- a/proxy/remoteaddr_test.go
+++ b/proxy/remoteaddr_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func newReq(remoteAddr, xff string) *http.Request {
+	r := &http.Request{RemoteAddr: remoteAddr, Header: http.Header{}}
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	return r
+}
+
+func TestRemoteAddr(t *testing.T) {
+	direct := &ProxyServer{config: &Config{Proxy: Proxy{BehindReverseProxy: false}}}
+	behind := &ProxyServer{config: &Config{Proxy: Proxy{BehindReverseProxy: true}}}
+
+	cases := []struct {
+		name   string
+		server *ProxyServer
+		remote string
+		xff    string
+		want   string
+	}{
+		{"not behind proxy ignores XFF", direct, "203.0.113.7:5000", "1.1.1.1", "203.0.113.7"},
+		{"behind proxy, no XFF, uses peer", behind, "203.0.113.7:5000", "", "203.0.113.7"},
+		{"behind proxy uses rightmost hop", behind, "10.0.0.1:5000", "1.1.1.1, 2.2.2.2, 9.9.9.9", "9.9.9.9"},
+		// The client prepends a spoofed IP; our proxy appends the real peer last.
+		{"spoofed left entry is ignored", behind, "10.0.0.1:5000", "6.6.6.6, 9.9.9.9", "9.9.9.9"},
+		{"whitespace is trimmed", behind, "10.0.0.1:5000", "evil , 9.9.9.9", "9.9.9.9"},
+		{"single valid entry", behind, "10.0.0.1:5000", "9.9.9.9", "9.9.9.9"},
+		{"invalid rightmost falls back to peer", behind, "203.0.113.7:5000", "9.9.9.9, garbage", "203.0.113.7"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.server.remoteAddr(newReq(c.remote, c.xff)); got != c.want {
+				t.Fatalf("remoteAddr(%q, XFF=%q) = %q, want %q", c.remote, c.xff, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes **H2** from the audit. `remoteAddr` trusted the entire `X-Forwarded-For` header when `behindReverseProxy` is set; `net.ParseIP` blocks injection but not spoofing. Since that IP drives every policy decision, a client could evade bans/limits and — with `banning.ipset` configured — make the pool run `sudo ipset add <victim-ip>` by sending a few malformed requests with a forged `X-Forwarded-For`, firewall-banning a third party.

Fix: use the **rightmost** XFF entry — the address our own reverse proxy appended for the peer that connected to it. Entries to the left are client-supplied and spoofable. Assumes a single trusted proxy that appends XFF (nginx `$proxy_add_x_forwarded_for`).

Table-driven test covers the spoofed-left-entry, multi-hop, whitespace, no-XFF, and invalid-rightmost cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)