### PR TITLE
rpc: guard nil results and error messages against node-driven panics

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -93,6 +93,9 @@ func (r *RPCClient) GetWork() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if rpcResp.Result == nil {
+		return nil, errors.New("eth_getWork returned no result")
+	}
 	var reply []string
 	err = json.Unmarshal(*rpcResp.Result, &reply)
 	return reply, err
@@ -157,6 +160,9 @@ func (r *RPCClient) SubmitBlock(params []string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if rpcResp.Result == nil {
+		return false, errors.New("eth_submitWork returned no result")
+	}
 	var reply bool
 	err = json.Unmarshal(*rpcResp.Result, &reply)
 	return reply, err
@@ -166,6 +172,9 @@ func (r *RPCClient) GetBalance(address string) (*big.Int, error) {
 	rpcResp, err := r.doPost(r.Url, "eth_getBalance", []string{address, "latest"})
 	if err != nil {
 		return nil, err
+	}
+	if rpcResp.Result == nil {
+		return nil, errors.New("eth_getBalance returned no result")
 	}
 	var reply string
 	err = json.Unmarshal(*rpcResp.Result, &reply)
@@ -182,6 +191,9 @@ func (r *RPCClient) Sign(from string, s string) (string, error) {
 	if err != nil {
 		return reply, err
 	}
+	if rpcResp.Result == nil {
+		return reply, errors.New("eth_sign returned no result")
+	}
 	err = json.Unmarshal(*rpcResp.Result, &reply)
 	if err != nil {
 		return reply, err
@@ -196,6 +208,9 @@ func (r *RPCClient) GetPeerCount() (int64, error) {
 	rpcResp, err := r.doPost(r.Url, "net_peerCount", nil)
 	if err != nil {
 		return 0, err
+	}
+	if rpcResp.Result == nil {
+		return 0, errors.New("net_peerCount returned no result")
 	}
 	var reply string
 	err = json.Unmarshal(*rpcResp.Result, &reply)
@@ -219,6 +234,9 @@ func (r *RPCClient) SendTransaction(from, to, gas, gasPrice, value string, autoG
 	var reply string
 	if err != nil {
 		return reply, err
+	}
+	if rpcResp.Result == nil {
+		return reply, errors.New("eth_sendTransaction returned no result")
 	}
 	err = json.Unmarshal(*rpcResp.Result, &reply)
 	if err != nil {
@@ -262,7 +280,10 @@ func (r *RPCClient) doPost(url string, method string, params interface{}) (*JSON
 	}
 	if rpcResp.Error != nil {
 		r.markSick()
-		return nil, errors.New(rpcResp.Error["message"].(string))
+		if msg, ok := rpcResp.Error["message"].(string); ok {
+			return nil, errors.New(msg)
+		}
+		return nil, fmt.Errorf("rpc error: %v", rpcResp.Error)
 	}
 	return rpcResp, err
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1,0 +1,61 @@
+package rpc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockNode returns an RPCClient pointed at a server that always replies with the
+// given JSON-RPC body.
+func mockNode(t *testing.T, body string) *RPCClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return NewRPCClient("test", srv.URL, "5s")
+}
+
+// A node reply with a null result must return an error, not panic on the nil
+// *json.RawMessage dereference (an unrecovered panic would kill the pool).
+func TestNullResultReturnsErrorNotPanic(t *testing.T) {
+	const nullResult = `{"jsonrpc":"2.0","id":0,"result":null}`
+
+	if _, err := mockNode(t, nullResult).GetWork(); err == nil {
+		t.Error("GetWork: expected an error for a null result")
+	}
+	if _, err := mockNode(t, nullResult).SubmitBlock([]string{"0x0", "0x0", "0x0"}); err == nil {
+		t.Error("SubmitBlock: expected an error for a null result")
+	}
+	if _, err := mockNode(t, nullResult).GetBalance("0x0"); err == nil {
+		t.Error("GetBalance: expected an error for a null result")
+	}
+	if _, err := mockNode(t, nullResult).GetPeerCount(); err == nil {
+		t.Error("GetPeerCount: expected an error for a null result")
+	}
+	if _, err := mockNode(t, nullResult).SendTransaction("0x0", "0x1", "", "", "0x0", true); err == nil {
+		t.Error("SendTransaction: expected an error for a null result")
+	}
+}
+
+// An error object without a string "message" field must not panic the type
+// assertion in doPost.
+func TestErrorWithoutMessageReturnsErrorNotPanic(t *testing.T) {
+	c := mockNode(t, `{"jsonrpc":"2.0","id":0,"error":{"code":-1}}`)
+	if _, err := c.GetWork(); err == nil {
+		t.Error("expected an error for a node error reply without a message")
+	}
+}
+
+func TestGetWorkValid(t *testing.T) {
+	c := mockNode(t, `{"jsonrpc":"2.0","id":0,"result":["0xheader","0xseed","0xtarget"]}`)
+	work, err := c.GetWork()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(work) != 3 || work[0] != "0xheader" {
+		t.Fatalf("unexpected work: %v", work)
+	}
+}


### PR DESCRIPTION
Fixes **L2** from the audit (and its siblings). Several RPC methods dereferenced `*rpcResp.Result` with no nil check — a node reply with `"result": null` panics on the nil `*json.RawMessage`. `doPost` asserted `rpcResp.Error["message"].(string)` without the comma-ok form, panicking on an error object lacking a string message. An unrecovered panic in a proxy or payout goroutine kills the whole process, so a buggy or hostile upstream node could crash the pool.

Fable flagged `GetWork`/`SubmitBlock`; the same unguarded deref is also in `GetBalance`, `Sign`, `GetPeerCount` and `SendTransaction` (the last in the payout path), so all six are guarded, plus the `doPost` error assertion.

Adds `rpc/rpc_test.go` (the package had no tests): a null result across the affected methods and an error reply without a message both return an error rather than panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)