### PR TITLE
storage,payouts: record found blocks atomically with the round

### DIFF
--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -512,7 +512,16 @@ func (u *BlockUnlocker) calculateRewards(block *storage.BlockData) (*big.Rat, *b
 		return nil, nil, nil, nil, err
 	}
 
-	rewards, err := calculateRewardsForShares(shares, block.TotalShares, minersProfit)
+	// Use the actual sum of round shares as the reward denominator rather than
+	// the block's cached TotalShares, so per-miner rewards always sum to exactly
+	// the block reward. This decouples payouts from the cached value, which lets
+	// WriteBlock record the candidate atomically with the round rename.
+	var totalShares int64
+	for _, n := range shares {
+		totalShares += n
+	}
+
+	rewards, err := calculateRewardsForShares(shares, totalShares, minersProfit)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -537,6 +546,16 @@ func (u *BlockUnlocker) calculateRewards(block *storage.BlockData) (*big.Rat, *b
 
 func calculateRewardsForShares(shares map[string]int64, total int64, reward *big.Rat) (map[string]int64, error) {
 	rewards := make(map[string]int64)
+
+	// Guard against a zero/negative denominator (corrupted round data): with
+	// shares present it would panic in big.NewRat; with none there is nothing to
+	// distribute.
+	if total <= 0 {
+		if len(shares) == 0 {
+			return rewards, nil
+		}
+		return nil, fmt.Errorf("cannot distribute reward over %d total shares", total)
+	}
 
 	for login, n := range shares {
 		percent := big.NewRat(n, total)

--- a/payouts/unlocker_test.go
+++ b/payouts/unlocker_test.go
@@ -40,6 +40,19 @@ func TestCalculateRewards(t *testing.T) {
 	}
 }
 
+func TestCalculateRewardsForSharesZeroTotal(t *testing.T) {
+	reward, _ := new(big.Rat).SetString("5000000000000000000")
+	// Non-empty shares with a zero denominator must error, not panic in big.NewRat.
+	if _, err := calculateRewardsForShares(map[string]int64{"0x0": 1}, 0, reward); err == nil {
+		t.Fatal("expected an error for a zero total with shares present")
+	}
+	// No shares and a zero total is simply a no-op.
+	rewards, err := calculateRewardsForShares(map[string]int64{}, 0, reward)
+	if err != nil || len(rewards) != 0 {
+		t.Fatalf("empty shares: rewards=%v err=%v", rewards, err)
+	}
+}
+
 func TestChargeFee(t *testing.T) {
 	orig, _ := new(big.Rat).SetString("5000000000000000000")
 	value, _ := new(big.Rat).SetString("5000000000000000000")

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -200,30 +200,34 @@ func (r *RedisClient) WriteBlock(login, id string, params []string, diff, roundD
 	ms := util.MakeTimestamp()
 	ts := ms / 1000
 
-	cmds, err := r.client.TxPipelined(ctx, func(tx redis.Pipeliner) error {
+	// Approximate the round's total shares for the candidate's (display-only)
+	// shares field: read the round before the pipeline and add this share. The
+	// unlocker recomputes the exact reward denominator from the round hash, so
+	// this value never affects payouts. Computing it here lets the candidate be
+	// inserted inside the same transaction that renames the round, so a crash
+	// can't consume the round without recording the found block.
+	roundCurrent, err := r.client.HGetAll(ctx, r.formatKey("shares", "roundCurrent")).Result()
+	if err != nil {
+		return false, err
+	}
+	totalShares := diff
+	for _, v := range roundCurrent {
+		n, _ := strconv.ParseInt(v, 10, 64)
+		totalShares += n
+	}
+	candidate := join(strings.Join(params, ":"), ts, roundDiff, totalShares)
+
+	_, err = r.client.TxPipelined(ctx, func(tx redis.Pipeliner) error {
 		r.writeShare(tx, ms, ts, login, id, diff, window)
 		tx.HSet(ctx, r.formatKey("stats"), "lastBlockFound", strconv.FormatInt(ts, 10))
 		tx.HDel(ctx, r.formatKey("stats"), "roundShares")
 		tx.ZIncrBy(ctx, r.formatKey("finders"), 1, login)
 		tx.HIncrBy(ctx, r.formatKey("miners", login), "blocksFound", 1)
 		tx.Rename(ctx, r.formatKey("shares", "roundCurrent"), r.formatRound(int64(height), params[0]))
-		tx.HGetAll(ctx, r.formatRound(int64(height), params[0]))
+		tx.ZAdd(ctx, r.formatKey("blocks", "candidates"), redis.Z{Score: float64(height), Member: candidate})
 		return nil
 	})
-	if err != nil {
-		return false, err
-	} else {
-		sharesMap, _ := cmds[10].(*redis.MapStringStringCmd).Result()
-		totalShares := int64(0)
-		for _, v := range sharesMap {
-			n, _ := strconv.ParseInt(v, 10, 64)
-			totalShares += n
-		}
-		hashHex := strings.Join(params, ":")
-		s := join(hashHex, ts, roundDiff, totalShares)
-		cmd := r.client.ZAdd(ctx, r.formatKey("blocks", "candidates"), redis.Z{Score: float64(height), Member: s})
-		return false, cmd.Err()
-	}
+	return false, err
 }
 
 func (r *RedisClient) writeShare(tx redis.Pipeliner, ms, ts int64, login, id string, diff int64, expire time.Duration) {

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -6,9 +6,56 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
+
+func TestWriteBlockRecordsCandidateAtomically(t *testing.T) {
+	reset()
+	// A round in progress.
+	r.client.HSet(ctx, r.formatKey("shares", "roundCurrent"), "0xaa", 100, "0xbb", 50)
+	r.client.HSet(ctx, r.formatKey("stats"), "roundShares", 150)
+
+	params := []string{"0xnonce", "0xpow", "0xmix"}
+	exist, err := r.WriteBlock("0xcc", "rig", params, 10, 1000, 42, time.Hour)
+	if err != nil || exist {
+		t.Fatalf("WriteBlock: exist=%v err=%v", exist, err)
+	}
+
+	// The round was renamed with the solver's own share added; roundCurrent gone.
+	shares, _ := r.GetRoundShares(42, "0xnonce")
+	if shares["0xaa"] != 100 || shares["0xbb"] != 50 || shares["0xcc"] != 10 {
+		t.Fatalf("round shares after block = %v", shares)
+	}
+	if n, _ := r.client.Exists(ctx, r.formatKey("shares", "roundCurrent")).Result(); n != 0 {
+		t.Fatal("roundCurrent should have been renamed away")
+	}
+
+	// The candidate was recorded atomically with totalShares = the round sum.
+	cands, err := r.GetCandidates(100)
+	if err != nil {
+		t.Fatalf("GetCandidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("want 1 candidate, got %d", len(cands))
+	}
+	c := cands[0]
+	if c.Height != 42 || c.Nonce != "0xnonce" || c.Difficulty != 1000 {
+		t.Fatalf("candidate mismatch: %+v", c)
+	}
+	if c.TotalShares != 160 {
+		t.Fatalf("candidate TotalShares = %d, want 160 (100+50+10)", c.TotalShares)
+	}
+
+	// roundShares cleared and blocksFound incremented.
+	if ok, _ := r.client.HExists(ctx, r.formatKey("stats"), "roundShares").Result(); ok {
+		t.Fatal("roundShares should have been deleted")
+	}
+	if bf, _ := r.client.HGet(ctx, r.formatKey("miners", "0xcc"), "blocksFound").Int64(); bf != 1 {
+		t.Fatalf("blocksFound = %d, want 1", bf)
+	}
+}
 
 var r *RedisClient
 


### PR DESCRIPTION
Fixes **M1** (and **L3**) from the audit.

**M1 — non-atomic block-candidate write.** `WriteBlock` renamed the round and reset `roundShares` inside a `TxPipelined`, then added the `blocks:candidates` entry with a **separate** `ZADD` afterward (the exact `totalShares` was only known post-`EXEC`). A crash in that window consumed the round without recording the block: the reward is on-chain but the block is never unlocked and miners are never credited.

Fix: the candidate `ZADD` now runs **inside** the same transaction as the rename. To do that without needing the exact sum post-`EXEC`, the unlocker (`calculateRewards`) now derives the reward denominator from the **actual sum of round shares** rather than the block's cached `TotalShares`. So the candidate's `totalShares` is a display-only approximation computed before the pipeline, and per-miner rewards always sum to exactly the block reward (strictly more correct under concurrent shares).

**L3 — panic on zero total.** `calculateRewardsForShares` now returns an error instead of dividing by zero in `big.NewRat` when the denominator is zero with shares present.

Tests: the candidate is written atomically with `totalShares` = the round sum (round renamed, roundShares cleared, blocksFound incremented); the zero-total guard errors rather than panicking. Full suite green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)