### PR TITLE
api: don't hold the account cache lock across Redis I/O

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -250,48 +250,67 @@ func (s *ApiServer) AccountIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 
 	login := strings.ToLower(mux.Vars(r)["login"])
-	s.minersMu.Lock()
-	defer s.minersMu.Unlock()
-
-	reply, ok := s.miners[login]
 	now := util.MakeTimestamp()
 	cacheIntv := int64(s.statsIntv / time.Millisecond)
-	// Refresh stats if stale
-	if !ok || reply.updatedAt < now-cacheIntv {
-		exist, err := s.backend.IsMinerExists(login)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			log.Printf("Failed to fetch stats from backend: %v", err)
-			return
-		}
-		if !exist {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
 
-		stats, err := s.backend.GetMinerStats(login, s.config.Payments)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			log.Printf("Failed to fetch stats from backend: %v", err)
-			return
-		}
-		workers, err := s.backend.CollectWorkersStats(s.hashrateWindow, s.hashrateLargeWindow, login)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			log.Printf("Failed to fetch stats from backend: %v", err)
-			return
-		}
-		for key, value := range workers {
-			stats[key] = value
-		}
-		stats["pageSize"] = s.config.Payments
-		reply = &Entry{stats: stats, updatedAt: now}
-		s.miners[login] = reply
+	// Fast path: serve a fresh cached entry under a read lock, so concurrent
+	// account requests don't serialize behind a single writer.
+	s.minersMu.RLock()
+	reply, ok := s.miners[login]
+	s.minersMu.RUnlock()
+	if ok && reply.updatedAt >= now-cacheIntv {
+		s.writeAccountStats(w, reply.stats)
+		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	err := json.NewEncoder(w).Encode(reply.stats)
+	// Slow path: fetch from the backend WITHOUT holding the lock, so a slow or
+	// hung Redis stalls only this request instead of every account lookup.
+	exist, err := s.backend.IsMinerExists(login)
 	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("Failed to fetch stats from backend: %v", err)
+		return
+	}
+	if !exist {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	stats, err := s.backend.GetMinerStats(login, s.config.Payments)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("Failed to fetch stats from backend: %v", err)
+		return
+	}
+	workers, err := s.backend.CollectWorkersStats(s.hashrateWindow, s.hashrateLargeWindow, login)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("Failed to fetch stats from backend: %v", err)
+		return
+	}
+	for key, value := range workers {
+		stats[key] = value
+	}
+	stats["pageSize"] = s.config.Payments
+	reply = &Entry{stats: stats, updatedAt: now}
+
+	// Store, and evict entries that have long gone stale so the cache stays
+	// bounded to recently-active miners instead of growing without limit.
+	s.minersMu.Lock()
+	s.miners[login] = reply
+	evictBefore := now - 20*cacheIntv
+	for k, e := range s.miners {
+		if e.updatedAt < evictBefore {
+			delete(s.miners, k)
+		}
+	}
+	s.minersMu.Unlock()
+
+	s.writeAccountStats(w, reply.stats)
+}
+
+func (s *ApiServer) writeAccountStats(w http.ResponseWriter, stats map[string]interface{}) {
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(stats); err != nil {
 		log.Println("Error serializing API response: ", err)
 	}
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -3,11 +3,14 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/etclabscore/open-etc-pool/storage"
+	"github.com/etclabscore/open-etc-pool/util"
 )
 
 const testAddr = "0x0000000000000000000000000000000000000000"
@@ -44,5 +47,26 @@ func TestAccountIndexNotFound(t *testing.T) {
 	s.AccountIndex(rec, accountRequest(testAddr))
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// A fresh cache entry is served without touching the backend — proven by an
+// unreachable backend still returning 200 with the cached stats. This also means
+// no backend I/O happens under any lock on the hot (cache-hit) path.
+func TestAccountIndexServesFreshCacheWithoutBackend(t *testing.T) {
+	s := newTestServer("127.0.0.1:1") // backend unreachable
+	s.statsIntv = time.Hour           // wide cache window
+
+	s.minersMu.Lock()
+	s.miners[testAddr] = &Entry{stats: map[string]interface{}{"balance": 42}, updatedAt: util.MakeTimestamp()}
+	s.minersMu.Unlock()
+
+	rec := httptest.NewRecorder()
+	s.AccountIndex(rec, accountRequest(testAddr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a fresh cache entry must serve without the backend)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"balance":42`) {
+		t.Fatalf("response did not contain the cached stats: %s", rec.Body.String())
 	}
 }


### PR DESCRIPTION
Fixes **M5** from the audit. `AccountIndex` held a write lock (`minersMu`) for the entire handler, spanning three blocking Redis calls (`IsMinerExists`, `GetMinerStats`, `CollectWorkersStats`). Every `/api/accounts/*` request serialized behind that one mutex, so a slow or hung Redis stalled all account lookups — a DoS amplifier. The per-miner cache also never evicted and grew without bound.

Fix: serve fresh cache hits under a **read** lock; fetch from the backend with **no lock held**; take the write lock only to store, and evict long-stale entries there so the cache stays bounded to recently-active miners. The 200/404/500 behavior is unchanged (existing tests still pass), and a new test proves a fresh cache entry is served without touching the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)