### PR TITLE
policy: bound the stats map and time-box the ipset ban command

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os/exec"
@@ -12,6 +13,14 @@ import (
 	"github.com/etclabscore/open-etc-pool/storage"
 	"github.com/etclabscore/open-etc-pool/util"
 )
+
+// maxStatsEntries caps the per-IP stats map so a flood of distinct source IPs
+// can't grow it without bound between reset sweeps.
+const maxStatsEntries = 100000
+
+// banCmdTimeout bounds the external `ipset` command so a hung invocation can't
+// stall the ban workers (and, in turn, every ban-triggering request).
+const banCmdTimeout = 5 * time.Second
 
 type Config struct {
 	Workers         int     `json:"workers"`
@@ -170,13 +179,28 @@ func (s *PolicyServer) Get(ip string) *Stats {
 	s.statsMu.Lock()
 	defer s.statsMu.Unlock()
 
-	if x, ok := s.stats[ip]; !ok {
-		x = s.NewStats()
-		s.stats[ip] = x
-		return x
-	} else {
+	if x, ok := s.stats[ip]; ok {
 		x.heartbeat()
 		return x
+	}
+	// New IP. Keep the map bounded: when it reaches the cap, drop entries that
+	// have been idle past the reset window before adding another.
+	if len(s.stats) >= maxStatsEntries {
+		s.evictIdleLocked()
+	}
+	x := s.NewStats()
+	s.stats[ip] = x
+	return x
+}
+
+// evictIdleLocked removes stats for IPs idle past the reset window, keeping
+// banned entries. The caller must hold statsMu.
+func (s *PolicyServer) evictIdleLocked() {
+	now := util.MakeTimestamp()
+	for key, m := range s.stats {
+		if atomic.LoadInt32(&m.Banned) == 0 && now-atomic.LoadInt64(&m.LastBeat) >= s.timeout {
+			delete(s.stats, key)
+		}
 	}
 }
 
@@ -186,7 +210,15 @@ func (s *PolicyServer) BanClient(ip string) {
 }
 
 func (s *PolicyServer) IsBanned(ip string) bool {
-	x := s.Get(ip)
+	// A read-only lookup: an IP with no stats can't be banned, so don't allocate
+	// an entry here. IsBanned runs first on every connection, so allocating would
+	// let unseen IPs (including ones we immediately drop) grow the stats map.
+	s.statsMu.Lock()
+	x, ok := s.stats[ip]
+	s.statsMu.Unlock()
+	if !ok {
+		return false
+	}
 	return atomic.LoadInt32(&x.Banned) > 0
 }
 
@@ -252,6 +284,9 @@ func (s *PolicyServer) ApplySharePolicy(ip string, validShare bool) bool {
 	x.resetShares()
 	x.Unlock()
 
+	// invalidPercent is compared against invalid/valid, not invalid/total. Since
+	// a share was just counted above, validShares+invalidShares >= 1, so with no
+	// valid shares this is +Inf and bans (all-invalid), never 0/0.
 	ratio := invalidShares / validShares
 
 	if ratio >= s.config.Banning.InvalidPercent/100.0 {
@@ -314,7 +349,9 @@ func (s *PolicyServer) doBan(ip string) {
 
 	log.Printf("Banned %v with timeout %v on ipset %s", ip, timeout, set)
 
-	_, err := exec.Command(head, args...).Output()
+	cmdCtx, cancel := context.WithTimeout(context.Background(), banCmdTimeout)
+	defer cancel()
+	_, err := exec.CommandContext(cmdCtx, head, args...).Output()
 	if err != nil {
 		log.Printf("CMD Error: %s", err)
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,6 +1,40 @@
 package policy
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/etclabscore/open-etc-pool/util"
+)
+
+func TestIsBannedDoesNotAllocate(t *testing.T) {
+	s := &PolicyServer{config: &Config{}, stats: make(map[string]*Stats)}
+	if s.IsBanned("1.2.3.4") {
+		t.Fatal("an unknown IP must not be reported as banned")
+	}
+	if len(s.stats) != 0 {
+		t.Fatalf("IsBanned allocated a stats entry for an unknown IP (%d entries)", len(s.stats))
+	}
+}
+
+func TestEvictIdleStats(t *testing.T) {
+	now := util.MakeTimestamp()
+	s := &PolicyServer{config: &Config{}, stats: make(map[string]*Stats), timeout: 1000}
+	s.stats["idle"] = &Stats{LastBeat: now - 5000}             // idle past the window
+	s.stats["fresh"] = &Stats{LastBeat: now}                   // recently active
+	s.stats["banned"] = &Stats{LastBeat: now - 5000, Banned: 1} // idle but banned
+
+	s.evictIdleLocked()
+
+	if _, ok := s.stats["idle"]; ok {
+		t.Error("idle entry should have been evicted")
+	}
+	if _, ok := s.stats["fresh"]; !ok {
+		t.Error("fresh entry should have been kept")
+	}
+	if _, ok := s.stats["banned"]; !ok {
+		t.Error("banned entry should be kept even when idle")
+	}
+}
 
 // newTestServer builds a PolicyServer without Start() so the share-policy
 // decision can be exercised without a Redis backend or the background workers.


### PR DESCRIPTION
Fixes **M4** and **L4** from the audit (and documents **L1**).

**M4 — unbounded stats map.** `Get` allocated a `*Stats` for every IP, evicted only every `resetInterval` (default 60m). `IsBanned` — the first check on every connection — called `Get`, so even IPs we immediately drop added entries. Now `IsBanned` is a read-only lookup that doesn't allocate (an IP with no stats can't be banned), and `Get` caps the map, evicting idle non-banned entries when it hits the cap.

**L4 — `ipset` command with no timeout.** `doBan` ran `sudo ipset add …` with no timeout; a hung invocation would block the ban workers and, via the 64-slot ban channel, every ban-triggering request. Now uses `exec.CommandContext` with a 5s timeout.

**L1 — noted, not changed.** The audit flagged a possible `0/0` NaN in the ban ratio. It can't actually occur: `ApplySharePolicy` counts the share before the ratio, so `valid+invalid >= 1`; with no valid shares the ratio is `+Inf` and correctly bans. Changing the denominator to invalid/total would silently re-tune every operator's ban threshold, so only a clarifying comment was added.

Tests: `IsBanned` doesn't allocate for an unknown IP; idle eviction drops stale non-banned entries and keeps banned/fresh ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)