### PR TITLE
storage,proxy: fix low-height PoW-dedup underflow, warn on unused NiceHash config

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -76,6 +76,9 @@ func NewProxy(cfg *Config, backend *storage.RedisClient) *ProxyServer {
 		proxy.sessions = make(map[*Session]struct{})
 		go proxy.ListenTCP()
 	}
+	if cfg.Proxy.StratumNiceHash.Enabled {
+		log.Println("Warning: stratum_nice_hash is enabled in config, but the NiceHash stratum protocol is not implemented; no NiceHash listener is started")
+	}
 
 	proxy.fetchBlockTemplate()
 

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -162,8 +162,12 @@ func (r *RedisClient) GetNodeStates() ([]map[string]interface{}, error) {
 }
 
 func (r *RedisClient) checkPoWExist(height uint64, params []string) (bool, error) {
-	// Sweep PoW backlog for previous blocks, we have 3 templates back in RAM
-	r.client.ZRemRangeByScore(ctx, r.formatKey("pow"), "-inf", fmt.Sprint("(", height-8))
+	// Sweep PoW backlog for previous blocks, we have 3 templates back in RAM.
+	// Skip when height <= 8 so height-8 doesn't underflow (uint64) to a huge score
+	// and prune the whole dedup set, briefly disabling duplicate-share detection.
+	if height > 8 {
+		r.client.ZRemRangeByScore(ctx, r.formatKey("pow"), "-inf", fmt.Sprint("(", height-8))
+	}
 	val, err := r.client.ZAdd(ctx, r.formatKey("pow"), redis.Z{Score: float64(height), Member: strings.Join(params, ":")}).Result()
 	return val == 0, err
 }

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -376,6 +376,19 @@ func TestCollectLuckStats(t *testing.T) {
 	}
 }
 
+func TestCheckPoWExistLowHeightDedup(t *testing.T) {
+	reset()
+	params := []string{"0xn", "0xp", "0xm"}
+	// height 3 (< 8): the backlog sweep must be skipped so a uint64 underflow
+	// doesn't prune the dedup entry, and the duplicate is still detected.
+	if exist, err := r.checkPoWExist(3, params); err != nil || exist {
+		t.Fatalf("first submit at height 3: exist=%v err=%v", exist, err)
+	}
+	if exist, err := r.checkPoWExist(3, params); err != nil || !exist {
+		t.Fatalf("duplicate submit at height 3 must be detected: exist=%v err=%v", exist, err)
+	}
+}
+
 func reset() {
 	keys := r.client.Keys(ctx, r.prefix+":*").Val()
 	for _, k := range keys {


### PR DESCRIPTION
Fixes **L5** and the `stratum_nice_hash` footgun from the audit.

**L5 — dedup underflow at low heights.** `checkPoWExist` computes `height-8` as a `uint64`; for `height <= 8` this underflows to a huge value and `ZRemRangeByScore(..., "(<huge>")` prunes the **entire** PoW dedup set, briefly disabling duplicate-share detection. Only reachable on a fresh chain/testnet below height 8. Fix: skip the backlog sweep below height 9. Test: a duplicate at height 3 is still detected.

**Footgun — `stratum_nice_hash`.** The config block is parsed but no NiceHash stratum listener is ever started, so an operator who enables it silently gets nothing. Log a clear warning at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)