### PR TITLE
rpc/policy: two edge cases surfaced by the remediation review

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -143,7 +143,10 @@ func (s *PolicyServer) resetStats() {
 				total++
 			}
 		}
-		if now-lastBeat >= s.timeout {
+		// Don't drop a still-banned entry via the idle sweep; it is released only
+		// when its ban times out (above). IsBanned no longer heartbeats, so a
+		// banned IP that is merely being probed would otherwise be forgotten early.
+		if now-lastBeat >= s.timeout && atomic.LoadInt32(&m.Banned) == 0 {
 			delete(s.stats, key)
 			total++
 		}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -16,6 +16,28 @@ func TestIsBannedDoesNotAllocate(t *testing.T) {
 	}
 }
 
+func TestResetStatsKeepsBannedEntriesUntilBanTimeout(t *testing.T) {
+	now := util.MakeTimestamp()
+	s := &PolicyServer{
+		config:  &Config{Banning: Banning{Timeout: 3600}}, // 3600s ban timeout
+		stats:   make(map[string]*Stats),
+		timeout: 1000, // 1s idle reset window (ms)
+	}
+	// Banned and idle, but banned only just now: must survive the idle sweep.
+	s.stats["banned"] = &Stats{LastBeat: now - 100000, BannedAt: now, Banned: 1}
+	// Plain idle, not banned: should be swept.
+	s.stats["idle"] = &Stats{LastBeat: now - 100000}
+
+	s.resetStats()
+
+	if _, ok := s.stats["banned"]; !ok {
+		t.Error("a banned entry must survive the idle sweep until its ban times out")
+	}
+	if _, ok := s.stats["idle"]; ok {
+		t.Error("an idle, non-banned entry should have been swept")
+	}
+}
+
 func TestEvictIdleStats(t *testing.T) {
 	now := util.MakeTimestamp()
 	s := &PolicyServer{config: &Config{}, stats: make(map[string]*Stats), timeout: 1000}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -278,6 +278,12 @@ func (r *RPCClient) doPost(url string, method string, params interface{}) (*JSON
 		r.markSick()
 		return nil, err
 	}
+	// A whole-body JSON null decodes without error but leaves rpcResp nil, so
+	// guard before dereferencing it (a bad/hostile node must not panic the pool).
+	if rpcResp == nil {
+		r.markSick()
+		return nil, errors.New("empty rpc response")
+	}
 	if rpcResp.Error != nil {
 		r.markSick()
 		if msg, ok := rpcResp.Error["message"].(string); ok {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -49,6 +49,15 @@ func TestErrorWithoutMessageReturnsErrorNotPanic(t *testing.T) {
 	}
 }
 
+// A whole-body JSON null response is valid JSON that decodes to a nil struct;
+// it must return an error, not panic dereferencing it in doPost.
+func TestNullBodyReturnsErrorNotPanic(t *testing.T) {
+	c := mockNode(t, `null`)
+	if _, err := c.GetWork(); err == nil {
+		t.Fatal("expected an error for a null response body")
+	}
+}
+
 func TestGetWorkValid(t *testing.T) {
 	c := mockNode(t, `{"jsonrpc":"2.0","id":0,"result":["0xheader","0xseed","0xtarget"]}`)
 	work, err := c.GetWork()


### PR DESCRIPTION
Two small fixes an adversarial review of the audit remediation turned up.

**rpc — whole-body `null` response panics.** The earlier L2 fix guarded `rpcResp.Result` in each method but not `rpcResp` itself in `doPost`. A node reply whose entire body is JSON `null` decodes without error to a nil `*JSONRpcResp`, then `rpcResp.Error` nil-dereferences and panics the process. Now returns an error; the test reproduces the panic on the pre-fix code.

**policy — banned IPs dropped early by the idle sweep.** `resetStats` deletes entries idle past `resetInterval` with no `Banned` check. The M4 change made `IsBanned` stop heartbeating, so a banned IP that is only being probed keeps a stale `LastBeat` — and with `resetInterval < banning.timeout` and no ipset, its ban was forgotten at the reset sweep instead of at `banning.timeout`. Skip banned entries in the idle sweep (they are released only when the ban expires), matching `evictIdleLocked`. Shipped defaults (60m reset > 30m ban) never triggered it.

Full suite green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)