### PR TITLE
payouts: reconcile interrupted payouts by nonce, not just tx hash

### DIFF
--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -59,6 +59,7 @@ type payerRPC interface {
 	GetPeerCount() (int64, error)
 	SendTransaction(from, to, gas, gasPrice, value string, autoGas bool) (string, error)
 	GetTxReceipt(hash string) (*rpc.TxReceipt, error)
+	GetTxCount(address, tag string) (uint64, error)
 }
 
 func NewPayoutsProcessor(cfg *PayoutsConfig, backend *storage.RedisClient) *PayoutsProcessor {
@@ -164,6 +165,17 @@ func (u *PayoutsProcessor) process() {
 			break
 		}
 
+		// Read the nonce the node will assign to this payout up front (still
+		// pre-mutation, so a failure just retries next cycle). The pool is the
+		// only sender and this payout is the next tx, so this nonce is stable
+		// until we send; recording it lets resolvePayouts reconcile a crashed
+		// payout against the chain.
+		nonce, err := u.rpc.GetTxCount(u.config.Address, "pending")
+		if err != nil {
+			log.Printf("Unable to read pool account nonce, retrying next cycle: %v", err)
+			break
+		}
+
 		// Lock payments for current payout
 		err = u.backend.LockPayouts(login, amount)
 		if err != nil {
@@ -178,6 +190,15 @@ func (u *PayoutsProcessor) process() {
 		err = u.backend.UpdateBalance(login, amount)
 		if err != nil {
 			log.Printf("Failed to update balance for %s, %v Shannon: %v", login, amount, err)
+			u.halt = true
+			u.lastFail = err
+			break
+		}
+
+		// Record the payout nonce before broadcasting, so a crash any time after
+		// the send can be reconciled against the chain without double-paying.
+		if err = u.backend.SetPendingPaymentNonce(login, amount, nonce); err != nil {
+			log.Printf("Failed to record payout nonce for %s: %v", login, err)
 			u.halt = true
 			u.lastFail = err
 			break
@@ -300,14 +321,36 @@ func (self PayoutsProcessor) resolvePayouts() {
 		log.Printf("Resolving %v pending payment(s):\n%s", len(payments), formatPendingPayments(payments))
 
 		for _, v := range payments {
+			nonce, hasNonce, err := self.backend.GetPendingPaymentNonce(v.Address, v.Amount)
+			if err != nil {
+				log.Printf("Failed to read payout nonce for %s, leaving it for manual resolution: %v", v.Address, err)
+				return
+			}
 			txHash, err := self.backend.GetPendingPaymentTx(v.Address, v.Amount)
 			if err != nil {
 				log.Printf("Failed to read pending tx for %s, leaving it for manual resolution: %v", v.Address, err)
 				return
 			}
 
-			// No tx was ever broadcast (crash before or during send), so the
-			// payout never left the pool and the balance can be credited back.
+			// The recorded nonce is authoritative: the pool is the only sender, so
+			// whether the node consumed it tells us if the payout tx went out.
+			if hasNonce {
+				done, err := self.reconcileByNonce(v, nonce, txHash)
+				if err != nil {
+					log.Printf("Failed to reconcile payout for %s, leaving it for manual resolution: %v", v.Address, err)
+					return
+				}
+				if !done {
+					// Broadcast, still in the mempool at this nonce — not resolvable
+					// yet. Leave the payout (and the lock) as is; re-run once it mines.
+					log.Printf("Payout to %s (nonce %d) is still pending in the mempool; leave it and re-run RESOLVE_PAYOUT after it mines", v.Address, nonce)
+					return
+				}
+				continue
+			}
+
+			// Legacy record with no nonce (pre-upgrade, or a crash before the nonce
+			// was written, in which case nothing was sent). Fall back to the tx hash.
 			if txHash == "" {
 				if err := self.backend.RollbackBalance(v.Address, v.Amount); err != nil {
 					log.Printf("Failed to credit %v Shannon back to %s: %v", v.Amount, v.Address, err)
@@ -316,12 +359,7 @@ func (self PayoutsProcessor) resolvePayouts() {
 				log.Printf("Credited %v Shannon back to %s (no payout tx was broadcast)", v.Amount, v.Address)
 				continue
 			}
-
-			// A payout tx was broadcast. Only credit back if it provably reverted
-			// on-chain; when it succeeded, is still pending, or can't be checked,
-			// treat it as paid so an already-sent payout is never double-paid.
-			receipt, err := self.rpc.GetTxReceipt(txHash)
-			if err == nil && receipt != nil && receipt.Confirmed() && !receipt.Successful() {
+			if self.txReverted(txHash) {
 				if err := self.backend.RollbackBalance(v.Address, v.Amount); err != nil {
 					log.Printf("Failed to credit %v Shannon back to %s: %v", v.Amount, v.Address, err)
 					return
@@ -351,6 +389,53 @@ func (self PayoutsProcessor) resolvePayouts() {
 		self.bgSave()
 	}
 	log.Println("Payouts unlocked")
+}
+
+// reconcileByNonce resolves a pending payout from its recorded nonce. It returns
+// done=false only when the payout tx is still in the mempool at that nonce, in
+// which case the caller must leave the payout untouched for a later re-run.
+func (self PayoutsProcessor) reconcileByNonce(v *storage.PendingPayment, nonce uint64, txHash string) (bool, error) {
+	latest, err := self.rpc.GetTxCount(self.config.Address, "latest")
+	if err != nil {
+		return false, err
+	}
+	if latest > nonce {
+		// The tx at our nonce was mined, so the payout went out. Credit back only
+		// if it provably reverted (no value moved); otherwise record it as paid.
+		if txHash != "" && self.txReverted(txHash) {
+			if err := self.backend.RollbackBalance(v.Address, v.Amount); err != nil {
+				return false, err
+			}
+			log.Printf("Credited %v Shannon back to %s (payout tx %s reverted on-chain)", v.Amount, v.Address, txHash)
+			return true, nil
+		}
+		if err := self.backend.WritePayment(v.Address, txHash, v.Amount); err != nil {
+			return false, err
+		}
+		log.Printf("Recorded %v Shannon to %s as paid (nonce %d mined, tx %s); not crediting back", v.Amount, v.Address, nonce, txHash)
+		return true, nil
+	}
+
+	pending, err := self.rpc.GetTxCount(self.config.Address, "pending")
+	if err != nil {
+		return false, err
+	}
+	if pending > nonce {
+		return false, nil // broadcast, still sitting in the mempool at this nonce
+	}
+
+	// Neither mined nor pending at this nonce: the payout was never broadcast (or
+	// was dropped), so the balance is credited back and re-sent next cycle.
+	if err := self.backend.RollbackBalance(v.Address, v.Amount); err != nil {
+		return false, err
+	}
+	log.Printf("Credited %v Shannon back to %s (no tx at nonce %d; not broadcast)", v.Amount, v.Address, nonce)
+	return true, nil
+}
+
+func (self PayoutsProcessor) txReverted(txHash string) bool {
+	receipt, err := self.rpc.GetTxReceipt(txHash)
+	return err == nil && receipt != nil && receipt.Confirmed() && !receipt.Successful()
 }
 
 func (self PayoutsProcessor) mustResolvePayout() bool {

--- a/payouts/payer_test.go
+++ b/payouts/payer_test.go
@@ -18,6 +18,9 @@ type fakePayerRPC struct {
 	sendTxErr      error
 	receipt        *rpc.TxReceipt
 	receiptErr     error
+	txCountLatest  uint64
+	txCountPending uint64
+	txCountErr     error
 }
 
 func (f *fakePayerRPC) GetPeerCount() (int64, error)         { return f.peers, nil }
@@ -27,6 +30,15 @@ func (f *fakePayerRPC) SendTransaction(from, to, gas, gasPrice, value string, au
 	return "0xtxhash", f.sendTxErr
 }
 func (f *fakePayerRPC) GetTxReceipt(hash string) (*rpc.TxReceipt, error) { return f.receipt, f.receiptErr }
+func (f *fakePayerRPC) GetTxCount(addr, tag string) (uint64, error) {
+	if f.txCountErr != nil {
+		return 0, f.txCountErr
+	}
+	if tag == "pending" {
+		return f.txCountPending, nil
+	}
+	return f.txCountLatest, nil
+}
 
 const payerPrefix = "test-payer"
 

--- a/payouts/resolve_test.go
+++ b/payouts/resolve_test.go
@@ -125,6 +125,78 @@ func TestResolvePayoutsDoesNotCreditBackAlreadyBroadcast(t *testing.T) {
 	}
 }
 
+// With a recorded nonce, a payout whose nonce was mined is treated as paid (not
+// credited back) regardless of whether the tx hash made it to Redis.
+func TestResolvePayoutsPaidWhenNonceMined(t *testing.T) {
+	backend := resolveBackend(t)
+	const login, amount = "0xe1", int64(500)
+	seedStuckPayout(t, backend, login, amount, "0xhash")
+	if err := backend.SetPendingPaymentNonce(login, amount, 5); err != nil {
+		t.Fatalf("SetPendingPaymentNonce: %v", err)
+	}
+	// nonce 5 mined (latest 6).
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend,
+		rpc: &fakePayerRPC{txCountLatest: 6, txCountPending: 6}}
+	proc.resolvePayouts()
+
+	if bal, _ := backend.GetBalance(login); bal != 0 {
+		t.Fatalf("balance = %d, want 0 (a mined nonce means paid)", bal)
+	}
+	if paid := minerField(t, backend, login, "paid"); paid != amount {
+		t.Fatalf("paid = %d, want %d", paid, amount)
+	}
+	if locked, _ := backend.IsPayoutsLocked(); locked {
+		t.Fatal("lock not cleared")
+	}
+}
+
+// A recorded nonce that is neither mined nor pending means the payout never
+// broadcast, so the balance is credited back.
+func TestResolvePayoutsCreditsBackWhenNonceUnused(t *testing.T) {
+	backend := resolveBackend(t)
+	const login, amount = "0xe2", int64(600)
+	seedStuckPayout(t, backend, login, amount, "")
+	if err := backend.SetPendingPaymentNonce(login, amount, 5); err != nil {
+		t.Fatalf("SetPendingPaymentNonce: %v", err)
+	}
+	// nonce 5 unused (latest 5, pending 5).
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend,
+		rpc: &fakePayerRPC{txCountLatest: 5, txCountPending: 5}}
+	proc.resolvePayouts()
+
+	if bal, _ := backend.GetBalance(login); bal != amount {
+		t.Fatalf("balance = %d, want %d credited back", bal, amount)
+	}
+	if locked, _ := backend.IsPayoutsLocked(); locked {
+		t.Fatal("lock not cleared")
+	}
+}
+
+// A payout still in the mempool at its nonce is left untouched (and the lock
+// held) for a later re-run, never credited back.
+func TestResolvePayoutsLeavesInMempoolPayout(t *testing.T) {
+	backend := resolveBackend(t)
+	const login, amount = "0xe3", int64(700)
+	seedStuckPayout(t, backend, login, amount, "0xhash")
+	if err := backend.SetPendingPaymentNonce(login, amount, 5); err != nil {
+		t.Fatalf("SetPendingPaymentNonce: %v", err)
+	}
+	// nonce 5 not mined (latest 5) but in the mempool (pending 6).
+	proc := &PayoutsProcessor{config: &PayoutsConfig{BgSave: false}, backend: backend,
+		rpc: &fakePayerRPC{txCountLatest: 5, txCountPending: 6}}
+	proc.resolvePayouts()
+
+	if bal, _ := backend.GetBalance(login); bal != 0 {
+		t.Fatalf("balance = %d, want 0 (an in-mempool payout must not be credited back)", bal)
+	}
+	if p := backend.GetPendingPayments(); len(p) != 1 {
+		t.Fatalf("the pending payout should be left in place, got %d", len(p))
+	}
+	if locked, _ := backend.IsPayoutsLocked(); !locked {
+		t.Fatal("lock should be left held so the operator can re-run resolve")
+	}
+}
+
 // A payout whose tx was broadcast but provably reverted on-chain moved no value,
 // so the balance is credited back.
 func TestResolvePayoutsCreditsBackWhenTxReverted(t *testing.T) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -204,6 +204,24 @@ func (r *RPCClient) Sign(from string, s string) (string, error) {
 	return reply, err
 }
 
+// GetTxCount returns the transaction count (next nonce) of an address at the
+// given block tag ("latest" or "pending"). The payer uses it to reconcile a
+// crashed payout against the chain.
+func (r *RPCClient) GetTxCount(address, tag string) (uint64, error) {
+	rpcResp, err := r.doPost(r.Url, "eth_getTransactionCount", []string{address, tag})
+	if err != nil {
+		return 0, err
+	}
+	if rpcResp.Result == nil {
+		return 0, errors.New("eth_getTransactionCount returned no result")
+	}
+	var reply string
+	if err := json.Unmarshal(*rpcResp.Result, &reply); err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(strings.TrimPrefix(reply, "0x"), 16, 64)
+}
+
 func (r *RPCClient) GetPeerCount() (int64, error) {
 	rpcResp, err := r.doPost(r.Url, "net_peerCount", nil)
 	if err != nil {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -58,6 +58,17 @@ func TestNullBodyReturnsErrorNotPanic(t *testing.T) {
 	}
 }
 
+func TestGetTxCount(t *testing.T) {
+	c := mockNode(t, `{"jsonrpc":"2.0","id":0,"result":"0x2a"}`)
+	n, err := c.GetTxCount("0x0", "pending")
+	if err != nil {
+		t.Fatalf("GetTxCount: %v", err)
+	}
+	if n != 42 {
+		t.Fatalf("nonce = %d, want 42", n)
+	}
+}
+
 func TestGetWorkValid(t *testing.T) {
 	c := mockNode(t, `{"jsonrpc":"2.0","id":0,"result":["0xheader","0xseed","0xtarget"]}`)
 	work, err := c.GetWork()

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -423,6 +423,7 @@ func (r *RedisClient) RollbackBalance(login string, amount int64) error {
 		tx.HIncrBy(ctx, r.formatKey("finances"), "pending", (amount * -1))
 		tx.ZRem(ctx, r.formatKey("payments", "pending"), join(login, amount))
 		tx.HDel(ctx, r.formatKey("payments", "pendingtx"), join(login, amount))
+		tx.HDel(ctx, r.formatKey("payments", "pendingnonce"), join(login, amount))
 		return nil
 	})
 	return err
@@ -459,10 +460,33 @@ func (r *RedisClient) WritePayment(login, txHash string, amount int64) error {
 		tx.ZAdd(ctx, r.formatKey("payments", login), redis.Z{Score: float64(ts), Member: join(txHash, amount)})
 		tx.ZRem(ctx, r.formatKey("payments", "pending"), join(login, amount))
 		tx.HDel(ctx, r.formatKey("payments", "pendingtx"), join(login, amount))
+		tx.HDel(ctx, r.formatKey("payments", "pendingnonce"), join(login, amount))
 		tx.Del(ctx, r.formatKey("payments", "lock"))
 		return nil
 	})
 	return err
+}
+
+// SetPendingPaymentNonce records the pool account nonce assigned to the in-flight
+// payout, written before the tx is broadcast. resolvePayouts reconciles it
+// against the chain: since the pool is the only sender, whether that nonce was
+// consumed reliably says whether the payout tx went out.
+func (r *RedisClient) SetPendingPaymentNonce(login string, amount int64, nonce uint64) error {
+	return r.client.HSet(ctx, r.formatKey("payments", "pendingnonce"), join(login, amount), strconv.FormatUint(nonce, 10)).Err()
+}
+
+// GetPendingPaymentNonce returns the recorded payout nonce, and false if none was
+// recorded (a pre-upgrade record, or a crash before the nonce was written).
+func (r *RedisClient) GetPendingPaymentNonce(login string, amount int64) (uint64, bool, error) {
+	v, err := r.client.HGet(ctx, r.formatKey("payments", "pendingnonce"), join(login, amount)).Result()
+	if err == redis.Nil {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	nonce, err := strconv.ParseUint(v, 10, 64)
+	return nonce, true, err
 }
 
 func (r *RedisClient) WriteImmatureBlock(block *BlockData, roundRewards map[string]int64) error {


### PR DESCRIPTION
Closes the H1 residual windows Fable flagged in the remediation review, using the lightweight **read-and-reconcile-by-nonce** approach (no local signing, no new operator config).

## The residual

After the hash-based fix, two windows remained: (1) `SendTransaction` returns an error but the node actually broadcast the tx (lost HTTP response), and (2) a crash in the ~1-write gap between the send returning and recording the tx hash. Both let `resolvePayouts` credit the balance back and **double-pay**. The opposite bias marked a broadcast-but-dropped tx as paid, silently **shorting the miner**.

## The fix

Record the pool account **nonce** — read just before the send — alongside each pending payout. `LockPayouts` keeps exactly one payout in flight and the pool is the only sender, so whether the node consumed that nonce reliably says whether the payout tx went out. `resolvePayouts` reconciles against the chain via `eth_getTransactionCount`:

- **nonce mined** (`latest > nonce`) → paid (credited back only if the tx *reverted*);
- **nonce in the mempool** (`pending > nonce`) → left in place + lock held; operator re-runs `RESOLVE_PAYOUT` after it mines;
- **nonce unused** → never broadcast → credited back.

Records with no nonce (pre-upgrade, or a crash before the send) fall back to the existing tx-hash logic — **backward compatible**. This puts us ahead of the upstream sammy007 lineage, which credits back unconditionally.

Read-only reconciliation, one RPC method (`GetTxCount`), one Redis hash (`payments:pendingnonce`, cleared in `WritePayment`/`RollbackBalance`), ~40 lines. Tests cover the mined / in-mempool / unused cases and `GetTxCount`; the legacy tx-hash tests still pass.

> Not doing full managed/explicit-nonce signing (`eth_sendRawTransaction` + resend-same-nonce) — that adds key/gas management, real operator complexity, to close a window this already closes. `docs/PAYOUTS.md` still documents the old resolve flow (docs deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)