### PR TITLE
Add pool and per-miner hashrate charts

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -45,6 +45,24 @@ type Entry struct {
 	updatedAt int64
 }
 
+// Chart series are sampled at most this often and kept for this window.
+const (
+	chartSampleInterval = 10 * time.Minute
+	chartWindow         = 24 * time.Hour
+)
+
+func toInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case float64:
+		return int64(n)
+	}
+	return 0
+}
+
 func NewApiServer(cfg *ApiConfig, backend *storage.RedisClient) *ApiServer {
 	hashrateWindow := util.MustParseDuration(cfg.HashrateWindow)
 	hashrateLargeWindow := util.MustParseDuration(cfg.HashrateLargeWindow)
@@ -147,6 +165,12 @@ func (s *ApiServer) collectStats() {
 		}
 	}
 	s.stats.Store(stats)
+
+	// Sample the pool hashrate/miners time series for the charts.
+	if err := s.backend.WritePoolChart(util.MakeTimestamp()/1000, toInt64(stats["hashrate"]), toInt64(stats["minersTotal"]), chartSampleInterval, chartWindow); err != nil {
+		log.Printf("Failed to write pool chart: %v", err)
+	}
+
 	log.Printf("Stats collection finished %s", time.Since(start))
 }
 
@@ -173,6 +197,7 @@ func (s *ApiServer) StatsIndex(w http.ResponseWriter, r *http.Request) {
 		reply["immatureTotal"] = stats["immatureTotal"]
 		reply["candidatesTotal"] = stats["candidatesTotal"]
 	}
+	reply["poolCharts"] = s.backend.GetPoolChart()
 
 	err = json.NewEncoder(w).Encode(reply)
 	if err != nil {
@@ -291,6 +316,13 @@ func (s *ApiServer) AccountIndex(w http.ResponseWriter, r *http.Request) {
 		stats[key] = value
 	}
 	stats["pageSize"] = s.config.Payments
+
+	// Sample this miner's hashrate for its chart, then attach the series.
+	if err := s.backend.WriteMinerChart(login, now/1000, toInt64(stats["currentHashrate"]), chartSampleInterval, chartWindow); err != nil {
+		log.Printf("Failed to write miner chart: %v", err)
+	}
+	stats["charts"] = s.backend.GetMinerChart(login)
+
 	reply = &Entry{stats: stats, updatedAt: now}
 
 	// Store, and evict entries that have long gone stale so the cache stays

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -161,6 +161,63 @@ func (r *RedisClient) GetNodeStates() ([]map[string]interface{}, error) {
 	return v, nil
 }
 
+// chartSample appends a time-series point (a ":"-joined tuple scored by ts) no
+// more often than sampleInterval, and trims the series to window.
+func (r *RedisClient) chartSample(key string, ts int64, member string, sampleInterval, window time.Duration, expire bool) error {
+	if newest := r.client.ZRevRangeWithScores(ctx, key, 0, 0).Val(); len(newest) > 0 {
+		if ts-int64(newest[0].Score) < int64(sampleInterval.Seconds()) {
+			return nil
+		}
+	}
+	_, err := r.client.TxPipelined(ctx, func(tx redis.Pipeliner) error {
+		tx.ZAdd(ctx, key, redis.Z{Score: float64(ts), Member: member})
+		tx.ZRemRangeByScore(ctx, key, "-inf", fmt.Sprint("(", ts-int64(window.Seconds())))
+		if expire {
+			tx.Expire(ctx, key, window*2)
+		}
+		return nil
+	})
+	return err
+}
+
+func chartPoints(cmd *redis.ZSliceCmd, fields ...string) []map[string]interface{} {
+	out := []map[string]interface{}{}
+	for _, z := range cmd.Val() {
+		parts := strings.Split(z.Member.(string), ":")
+		if len(parts) < len(fields) {
+			continue
+		}
+		point := make(map[string]interface{}, len(fields))
+		for i, name := range fields {
+			n, _ := strconv.ParseInt(parts[i], 10, 64)
+			point[name] = n
+		}
+		out = append(out, point)
+	}
+	return out
+}
+
+// WritePoolChart records a pool-wide sample (hashrate, miners online) at ts.
+func (r *RedisClient) WritePoolChart(ts, hashrate, miners int64, sampleInterval, window time.Duration) error {
+	return r.chartSample(r.formatKey("charts", "pool"), ts, join(ts, hashrate, miners), sampleInterval, window, false)
+}
+
+// GetPoolChart returns the pool chart samples, oldest first.
+func (r *RedisClient) GetPoolChart() []map[string]interface{} {
+	return chartPoints(r.client.ZRangeWithScores(ctx, r.formatKey("charts", "pool"), 0, -1), "x", "hashrate", "minersOnline")
+}
+
+// WriteMinerChart records a per-miner hashrate sample at ts. The key expires so
+// an inactive miner's series is reclaimed.
+func (r *RedisClient) WriteMinerChart(login string, ts, hashrate int64, sampleInterval, window time.Duration) error {
+	return r.chartSample(r.formatKey("charts", "miner", login), ts, join(ts, hashrate), sampleInterval, window, true)
+}
+
+// GetMinerChart returns a miner's hashrate samples, oldest first.
+func (r *RedisClient) GetMinerChart(login string) []map[string]interface{} {
+	return chartPoints(r.client.ZRangeWithScores(ctx, r.formatKey("charts", "miner", login), 0, -1), "x", "hashrate")
+}
+
 func (r *RedisClient) checkPoWExist(height uint64, params []string) (bool, error) {
 	// Sweep PoW backlog for previous blocks, we have 3 templates back in RAM.
 	// Skip when height <= 8 so height-8 doesn't underflow (uint64) to a huge score

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -396,6 +396,63 @@ func reset() {
 	}
 }
 
+func TestPoolChartSampleGateAndTrim(t *testing.T) {
+	reset()
+	const sample = 10 * time.Minute // 600s gate
+	const window = time.Hour         // 3600s
+
+	if err := r.WritePoolChart(1000, 500, 3, sample, window); err != nil {
+		t.Fatal(err)
+	}
+	// Within the sample interval -> gated, dropped.
+	if err := r.WritePoolChart(1100, 999, 9, sample, window); err != nil {
+		t.Fatal(err)
+	}
+	pts := r.GetPoolChart()
+	if len(pts) != 1 {
+		t.Fatalf("want 1 point after a gated sample, got %d", len(pts))
+	}
+	if pts[0]["hashrate"].(int64) != 500 || pts[0]["minersOnline"].(int64) != 3 || pts[0]["x"].(int64) != 1000 {
+		t.Fatalf("point = %v", pts[0])
+	}
+
+	// Past the interval -> lands.
+	if err := r.WritePoolChart(1601, 700, 4, sample, window); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.GetPoolChart()) != 2 {
+		t.Fatalf("want 2 points, got %d", len(r.GetPoolChart()))
+	}
+
+	// A sample far ahead trims points older than the window (the ts=1000 point).
+	if err := r.WritePoolChart(5000, 800, 5, sample, window); err != nil {
+		t.Fatal(err)
+	}
+	pts = r.GetPoolChart()
+	if len(pts) != 2 {
+		t.Fatalf("want 2 points after trim, got %d", len(pts))
+	}
+	for _, p := range pts {
+		if p["x"].(int64) == 1000 {
+			t.Fatal("a point older than the window should have been trimmed")
+		}
+	}
+}
+
+func TestMinerChartRoundTrip(t *testing.T) {
+	reset()
+	if err := r.WriteMinerChart("0xaa", 1000, 1200, time.Minute, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	pts := r.GetMinerChart("0xaa")
+	if len(pts) != 1 || pts[0]["hashrate"].(int64) != 1200 || pts[0]["x"].(int64) != 1000 {
+		t.Fatalf("miner chart = %v", pts)
+	}
+	if len(r.GetMinerChart("0xbb")) != 0 {
+		t.Fatal("unknown miner should have an empty chart")
+	}
+}
+
 func TestLockPayoutsContention(t *testing.T) {
 	reset()
 

--- a/web/src/lib/Chart.svelte
+++ b/web/src/lib/Chart.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import type { ChartPoint } from './types';
+
+  // A dependency-free SVG line/area chart. Self-contained so it works under the
+  // pool's strict Content-Security-Policy (no external chart library).
+  let {
+    points = [],
+    value,
+    format,
+    label,
+  }: {
+    points: ChartPoint[];
+    value: (p: ChartPoint) => number;
+    format: (v: number) => string;
+    label: string;
+  } = $props();
+
+  const W = 600;
+  const H = 160;
+  const pad = { l: 4, r: 4, t: 10, b: 4 };
+
+  const series = $derived(
+    points.map((p) => ({ x: p.x, y: value(p) })).filter((p) => Number.isFinite(p.y)),
+  );
+
+  const bounds = $derived.by(() => {
+    if (series.length < 2) return null;
+    const xs = series.map((p) => p.x);
+    const ys = series.map((p) => p.y);
+    const xMin = Math.min(...xs);
+    const xMax = Math.max(...xs);
+    const yMax = Math.max(...ys, 1);
+    // A little floor headroom so a steady series isn't a flat line at the top.
+    const yMin = Math.min(Math.min(...ys), yMax * 0.75);
+    return { xMin, xMax, yMin, yMax };
+  });
+
+  function px(x: number, b: { xMin: number; xMax: number }): number {
+    const span = b.xMax - b.xMin || 1;
+    return pad.l + ((x - b.xMin) / span) * (W - pad.l - pad.r);
+  }
+  function py(y: number, b: { yMin: number; yMax: number }): number {
+    const span = b.yMax - b.yMin || 1;
+    return pad.t + (1 - (y - b.yMin) / span) * (H - pad.t - pad.b);
+  }
+
+  const line = $derived.by(() => {
+    const b = bounds;
+    if (!b) return '';
+    return series.map((p, i) => `${i ? 'L' : 'M'}${px(p.x, b).toFixed(1)},${py(p.y, b).toFixed(1)}`).join(' ');
+  });
+  const area = $derived.by(() => {
+    const b = bounds;
+    if (!b) return '';
+    const x0 = px(series[0].x, b).toFixed(1);
+    const x1 = px(series[series.length - 1].x, b).toFixed(1);
+    const base = (H - pad.b).toFixed(1);
+    return `${line} L${x1},${base} L${x0},${base} Z`;
+  });
+
+  const peak = $derived(series.length ? Math.max(...series.map((p) => p.y)) : 0);
+</script>
+
+<div class="chart">
+  <div class="chart-head">
+    <span class="chart-label">{label}</span>
+    {#if series.length >= 2}<span class="chart-peak">peak {format(peak)}</span>{/if}
+  </div>
+  {#if series.length >= 2}
+    <svg class="chart-svg" viewBox="0 0 {W} {H}" preserveAspectRatio="none" role="img" aria-label={label}>
+      <path class="chart-fill" d={area} />
+      <path class="chart-line" d={line} />
+    </svg>
+  {:else}
+    <p class="chart-empty">Not enough data yet — check back soon.</p>
+  {/if}
+</div>
+
+<style>
+  .chart {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    margin: 18px 0;
+  }
+  .chart-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 8px;
+  }
+  .chart-label {
+    font-weight: 600;
+    color: var(--charcoal);
+  }
+  .chart-peak {
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .chart-svg {
+    display: block;
+    width: 100%;
+    height: 150px;
+  }
+  .chart-line {
+    fill: none;
+    stroke: var(--etc-green);
+    stroke-width: 2;
+    stroke-linejoin: round;
+    vector-effect: non-scaling-stroke;
+  }
+  .chart-fill {
+    fill: var(--etc-green);
+    opacity: 0.12;
+    stroke: none;
+  }
+  .chart-empty {
+    color: var(--muted);
+    font-size: 13px;
+    margin: 8px 0 0;
+  }
+</style>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -52,6 +52,13 @@ export interface Worker {
 export type PoolStats = Record<string, number | string>;
 export type Luck = Record<string, { luck: number; uncleRate: number; orphanRate: number }>;
 
+// One time-series sample. x is unix seconds; the rest depend on the series.
+export interface ChartPoint {
+  x: number;
+  hashrate: number;
+  minersOnline?: number;
+}
+
 export interface StatsResponse {
   nodes: NodeState[];
   now?: number;
@@ -61,6 +68,7 @@ export interface StatsResponse {
   maturedTotal?: number;
   immatureTotal?: number;
   candidatesTotal?: number;
+  poolCharts?: ChartPoint[];
 }
 
 export interface MinersResponse {
@@ -99,4 +107,5 @@ export interface AccountResponse {
   hashrate: number; // Σ hr2 (3h)
   currentHashrate: number; // Σ hr (30m)
   pageSize: number;
+  charts?: ChartPoint[];
 }

--- a/web/src/routes/Account.svelte
+++ b/web/src/routes/Account.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import Icon from '../lib/Icon.svelte';
+  import Chart from '../lib/Chart.svelte';
   import { config } from '../lib/config';
   import { statsPoller } from '../lib/stores';
   import { getAccount, NotFoundError } from '../lib/api';
@@ -96,6 +97,14 @@
       </div>
     </div>
   </section>
+
+  {#if data.charts && data.charts.length}
+    <Chart
+      points={data.charts}
+      value={(p) => p.hashrate}
+      format={formatHashrate}
+      label="Your Hash Rate (24h)" />
+  {/if}
 
   <div class="tabs">
     <a href={'#/account/' + login} class:active={tab === 'workers'}>

--- a/web/src/routes/Home.svelte
+++ b/web/src/routes/Home.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Icon from '../lib/Icon.svelte';
+  import Chart from '../lib/Chart.svelte';
   import { config } from '../lib/config';
   import { statsPoller } from '../lib/stores';
   import { formatHashrate, formatNumber, formatPercent, formatRelative, metricPrefix, secondsToMs } from '../lib/format';
@@ -71,6 +72,14 @@
     </div>
   </div>
 </section>
+
+{#if $statsPoller.data?.poolCharts && $statsPoller.data.poolCharts.length}
+  <Chart
+    points={$statsPoller.data.poolCharts}
+    value={(p) => p.hashrate}
+    format={formatHashrate}
+    label="Pool Hash Rate (24h)" />
+{/if}
 
 <h4>Your Stats &amp; Payment History</h4>
 <form class="input-group" onsubmit={lookup}>


### PR DESCRIPTION
Persists a 24h hashrate time series in Redis and renders it as a chart on the pool home and account pages.

## Screenshots

Pool hashrate chart on the home page (light / dark):

| | |
|---|---|
| ![Pool chart (light)](https://raw.githubusercontent.com/etclabscore/open-etc-pool/master/docs/img/home.png) | ![Pool chart (dark)](https://raw.githubusercontent.com/etclabscore/open-etc-pool/master/docs/img/home-dark.png) |

Per-miner hashrate chart on the account page:

![Miner chart](https://raw.githubusercontent.com/etclabscore/open-etc-pool/master/docs/img/account.png)


## Backend
- **storage**: `chartSample` writes `":"`-joined, timestamp-scored points to a sorted set, gated to at most one sample per interval and trimmed to the retention window.
  - `WritePoolChart` / `GetPoolChart` — pool hashrate + miners online.
  - `WriteMinerChart` / `GetMinerChart` — per-miner hashrate; the key expires so an inactive miner's series is reclaimed.
- **api**: samples the pool series in `collectStats` and exposes it as `poolCharts` on `/api/stats`; samples the miner series in `AccountIndex` and exposes it as `charts` on `/api/accounts/:login`. Sampling is bounded to every 10m over a 24h window.

## Frontend
- `Chart.svelte` — a dependency-free SVG line/area chart that renders under the pool's strict Content-Security-Policy (no external chart library), with an empty state until enough points accumulate.
- The pool chart is wired into Home, the per-miner chart into Account.

## Tests
- `TestPoolChartSampleGateAndTrim` — verifies the per-interval sampling gate and window trimming.
- `TestMinerChartRoundTrip` — verifies write/read of a miner series.

Backend passes `go test -race ./...`; the frontend passes `svelte-check` (0 errors) and builds clean.

## Credit
Builds on the charting idea from #9 and #27 by @ahonder — a Redis-backed pool/per-miner hashrate series surfaced as charts. This is a fresh, leaner implementation for the modernized stack (a single generic sampler + a dependency-free SVG component rather than Highcharts), but the concept is theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
