### PR TITLE
Stamp the build version and expose it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,11 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
+        version = "0.9.0";
+
         open-etc-pool = pkgs.buildGoModule {
           pname = "open-etc-pool";
-          version = "0.0.0+${self.shortRev or "dirty"}";
+          version = "${version}+${self.shortRev or "dirty"}";
           src = self;
 
           # Hash of the module dependencies. Recompute after go.mod/go.sum
@@ -37,7 +39,7 @@
 
           # The pool is pure Go — build a static binary (smaller image, no libc).
           env.CGO_ENABLED = "0";
-          ldflags = [ "-s" "-w" ];
+          ldflags = [ "-s" "-w" "-X main.version=${version}+${self.shortRev or "dirty"}" ];
 
           meta = with pkgs.lib; {
             description = "Open source Ethereum Classic mining pool";

--- a/main.go
+++ b/main.go
@@ -15,10 +15,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/etclabscore/open-etc-pool/api"
+	"github.com/etclabscore/open-etc-pool/metrics"
 	"github.com/etclabscore/open-etc-pool/payouts"
 	"github.com/etclabscore/open-etc-pool/proxy"
 	"github.com/etclabscore/open-etc-pool/storage"
 )
+
+// version is stamped at build time via -ldflags "-X main.version=...".
+// It stays "dev" for a plain `go build`.
+var version = "dev"
 
 var cfg proxy.Config
 var backend *storage.RedisClient
@@ -80,6 +85,9 @@ func readConfig(cfg *proxy.Config) {
 }
 
 func main() {
+	log.Printf("open-etc-pool %s", version)
+	metrics.SetBuildInfo(version)
+
 	readConfig(&cfg)
 
 	if cfg.Threads > 0 {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -55,7 +55,20 @@ var (
 		Name: "oep_upstream_healthy",
 		Help: "Upstream node health from the latest check (1 = healthy, 0 = sick).",
 	}, []string{"url"})
+
+	// BuildInfo is the conventional build-info gauge: its value is always 1 and
+	// the running version rides in the "version" label, so dashboards can group
+	// and alert on the deployed version.
+	BuildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "oep_build_info",
+		Help: "Build information; the value is always 1, with the version in the label.",
+	}, []string{"version"})
 )
+
+// SetBuildInfo records the running version on the build-info gauge.
+func SetBuildInfo(version string) {
+	BuildInfo.WithLabelValues(version).Set(1)
+}
 
 // ShareOutcome records a single share outcome. Use the Share* constants.
 func ShareOutcome(status string) {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-etc-pool-web",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The binary had no version identity — nothing logged at startup, no version in metrics, and `flake.nix` / `web/package.json` both read `0.0.0`. Ahead of cutting a first tagged release, give it one.

- `main.go`: a `version` variable (default `"dev"`), set at build time via `-ldflags "-X main.version=..."`; logged at startup.
- `metrics`: a conventional `oep_build_info` gauge (value always 1, version in the label) so dashboards can group and alert on the deployed version.
- `flake.nix`: stamps the version into the binary (`0.9.0+<rev>`) and sets the package version.
- `web/package.json`: bumped `0.0.0` → `0.9.0`.

A plain `go build` still reports `dev`. Verified: `go build -ldflags "-X main.version=..."` prints the stamped version at startup; full `-race` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)