### PR TITLE
docs: document the NiceHash and PROP-only limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Domain docs: [PAYOUTS](docs/PAYOUTS.md) · [POLICIES](docs/POLICIES.md) · [STRA
 - If `poolFeeAddress` is unset, pool profit stays on the coinbase address; if set,
   keep a little dust on it for gas.
 
+## Limitations
+
+- **PROP payouts only** — no SOLO or PPLNS scheme yet.
+- **No NiceHash support** — the pool speaks the eth-proxy stratum protocol, not
+  the `EthereumStratum/1.0.0` variant NiceHash uses; the `stratum_nice_hash`
+  config block is a placeholder (see [`docs/STRATUM.md`](docs/STRATUM.md)).
+- **No exchange price feed** — balances are shown in ETC, not fiat.
+
 ## Mordor (testnet)
 
 Set `network` to `mordor` in the pool config, and `network` to `mordor` in

--- a/docs/STRATUM.md
+++ b/docs/STRATUM.md
@@ -141,3 +141,15 @@ Pool MAY return exception on invalid share submission usually followed by tempor
 ```javascript
 { "id": 1, "jsonrpc": "2.0", "result": true }
 ```
+
+## NiceHash (not supported)
+
+This pool speaks the eth-proxy style protocol described above (`eth_submitLogin`
+/ `eth_getWork` / `eth_submitWork`). It does **not** implement the
+`EthereumStratum/1.0.0` variant NiceHash uses (`mining.subscribe` /
+`mining.authorize` with extranonce subscription and `mining.set_difficulty` /
+`mining.notify` jobs).
+
+The `stratum_nice_hash` block in `config.example.json` is a placeholder: no
+NiceHash listener is started for it. Enabling it logs a warning and otherwise
+has no effect. NiceHash-compatible stratum is tracked as a future addition.


### PR DESCRIPTION
NiceHash incompatibility was only surfaced as a runtime log warning. Document it where operators look:

- `docs/STRATUM.md` — a "NiceHash (not supported)" section explaining the pool speaks the eth-proxy protocol, not `EthereumStratum/1.0.0`, and that the `stratum_nice_hash` config block is an inert placeholder.
- `README.md` — a "Limitations" section: PROP-only payouts, no NiceHash, no exchange price feed.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)