### PR TITLE
test: skip Redis-backed tests when Redis is absent

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -43,6 +43,9 @@ func TestAccountIndexBackendError(t *testing.T) {
 // A miner that does not exist, with a healthy backend, is a genuine 404.
 func TestAccountIndexNotFound(t *testing.T) {
 	s := newTestServer("127.0.0.1:6379")
+	if _, err := s.backend.Check(); err != nil {
+		t.Skipf("Redis not available, skipping: %v", err)
+	}
 	rec := httptest.NewRecorder()
 	s.AccountIndex(rec, accountRequest(testAddr))
 	if rec.Code != http.StatusNotFound {

--- a/payouts/payer_test.go
+++ b/payouts/payer_test.go
@@ -42,9 +42,20 @@ func (f *fakePayerRPC) GetTxCount(addr, tag string) (uint64, error) {
 
 const payerPrefix = "test-payer"
 
+// requireRedis skips the calling test when the local Redis these
+// integration-style tests need isn't reachable, instead of failing on the
+// first backend operation.
+func requireRedis(t *testing.T, backend *storage.RedisClient) {
+	t.Helper()
+	if _, err := backend.Check(); err != nil {
+		t.Skipf("Redis not available, skipping: %v", err)
+	}
+}
+
 func newTestPayer(t *testing.T, fake payerRPC) *PayoutsProcessor {
 	t.Helper()
 	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, payerPrefix)
+	requireRedis(t, backend)
 
 	ctx := context.Background()
 	if keys, _ := backend.Client().Keys(ctx, payerPrefix+":*").Result(); len(keys) > 0 {

--- a/payouts/shutdown_test.go
+++ b/payouts/shutdown_test.go
@@ -30,6 +30,7 @@ func assertStartReturns(t *testing.T, name string, start func()) {
 
 func TestBlockUnlockerStopsOnContextCancel(t *testing.T) {
 	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, "test-graceful-unlocker")
+	requireRedis(t, backend)
 	network := "classic"
 	u := NewBlockUnlocker(&UnlockerConfig{
 		Interval:      "1h",
@@ -46,6 +47,7 @@ func TestBlockUnlockerStopsOnContextCancel(t *testing.T) {
 
 func TestPayoutsProcessorStopsOnContextCancel(t *testing.T) {
 	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, "test-graceful-payer")
+	requireRedis(t, backend)
 	u := NewPayoutsProcessor(&PayoutsConfig{
 		Interval: "1h",
 		Daemon:   "http://127.0.0.1:1",

--- a/payouts/unlocker_recovery_test.go
+++ b/payouts/unlocker_recovery_test.go
@@ -30,9 +30,11 @@ func (f *fakeUnlockerRPC) GetUncleByBlockNumberAndIndex(int64, int) (*rpc.GetBlo
 
 func (f *fakeUnlockerRPC) GetTxReceipt(string) (*rpc.TxReceipt, error) { return nil, nil }
 
-func newTestUnlocker(rpcClient unlockerRPC) *BlockUnlocker {
+func newTestUnlocker(t *testing.T, rpcClient unlockerRPC) *BlockUnlocker {
+	t.Helper()
 	network := "classic"
 	backend := storage.NewRedisClient(&storage.Config{Endpoint: "127.0.0.1:6379"}, "test-unlock-recover")
+	requireRedis(t, backend)
 	u := NewBlockUnlocker(&UnlockerConfig{
 		Interval:      "1h",
 		Depth:         120,
@@ -48,7 +50,7 @@ func newTestUnlocker(rpcClient unlockerRPC) *BlockUnlocker {
 // node is reachable again.
 func TestUnlockerRecoversFromTransientError(t *testing.T) {
 	fake := &fakeUnlockerRPC{}
-	u := newTestUnlocker(fake)
+	u := newTestUnlocker(t, fake)
 
 	fake.pendingErr = errors.New("node unreachable")
 	u.runCycle()
@@ -73,7 +75,7 @@ func TestUnlockerRecoversFromTransientError(t *testing.T) {
 // (a restart is required) instead of looping forever on a wedged node.
 func TestUnlockerRelatchesAfterPersistentFailure(t *testing.T) {
 	fake := &fakeUnlockerRPC{pendingErr: errors.New("wedged")}
-	u := newTestUnlocker(fake)
+	u := newTestUnlocker(t, fake)
 
 	for i := 0; i < maxUnlockFailsInARow; i++ {
 		u.runCycle()

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"log"
 	"os"
 	"reflect"
 	"strconv"
@@ -63,6 +64,12 @@ const prefix = "test"
 
 func TestMain(m *testing.M) {
 	r = NewRedisClient(&Config{Endpoint: "127.0.0.1:6379"}, prefix)
+	// Every test in this package needs Redis; skip the whole package (rather
+	// than panicking on empty results) when it isn't reachable.
+	if _, err := r.Check(); err != nil {
+		log.Printf("Redis not available on 127.0.0.1:6379, skipping storage tests: %v", err)
+		os.Exit(0)
+	}
 	reset()
 	c := m.Run()
 	reset()


### PR DESCRIPTION
Running `go test ./...` without a local Redis panicked in the storage/api/payout packages (empty results indexed out of range) instead of skipping like `resolve_test.go` and the e2e test already do — a rough first-contributor experience.

Gate the Redis-backed tests on a reachability check:

- **storage** — skip the whole package in `TestMain` (every test needs Redis).
- **api** — skip only the one test that uses a real backend; the deliberately-unreachable-Redis error-path tests still run.
- **payouts** — a `requireRedis` helper skips the integration-style unlocker/payer/shutdown tests, while the Redis-independent ECIP-1017 reward-math tests keep running.

Verified both ways: with Redis down the packages skip cleanly (reward-math tests still execute); with Redis up the full `-race` suite passes. CI (which always has Redis) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)